### PR TITLE
Gawron/ZPI-1-ZPI-40-BE-36-Search-offer-by-configuration-and-adjusted-to-it-price

### DIFF
--- a/src/main/java/com/example/petbuddybackend/utils/specification/OfferSpecificationUtils.java
+++ b/src/main/java/com/example/petbuddybackend/utils/specification/OfferSpecificationUtils.java
@@ -45,14 +45,6 @@ public final class OfferSpecificationUtils {
             spec = spec.and(amenitiesIn(filters.amenities()));
         }
 
-//        if(filters.minPrice() != null) {
-//            spec = spec.and(minPrice(filters.minPrice()));
-//        }
-//
-//        if(filters.maxPrice() != null) {
-//            spec = spec.and(maxPrice(filters.maxPrice()));
-//        }
-
         if(CollectionUtil.isNotEmpty(filters.animalAttributeIds())) {
             spec = spec.and(animalAttributeIdsIn(filters.animalAttributeIds(), filters.minPrice(), filters.maxPrice()));
         }
@@ -73,20 +65,6 @@ public final class OfferSpecificationUtils {
             Join<Offer, AnimalAmenity> animalAmenityJoin = root.join(ANIMAl_AMENITIES);
             Join<AnimalAmenity, Amenity> amenityJoin = animalAmenityJoin.join(AMENITY);
             return amenityJoin.get(AMENITY_NAME).in(amenities);
-        };
-    }
-
-    private static Specification<Offer> minPrice(Double minPrice) {
-        return (root, query, criteriaBuilder) -> {
-            Join<Offer, OfferConfiguration> offerOfferConfigurationJoin = root.join(OFFER_CONFIGURATIONS);
-            return criteriaBuilder.greaterThanOrEqualTo(offerOfferConfigurationJoin.get(PRICE), minPrice);
-        };
-    }
-
-    private static Specification<Offer> maxPrice(Double maxPrice) {
-        return (root, query, criteriaBuilder) -> {
-            Join<Offer, OfferConfiguration> offerOfferConfigurationJoin = root.join(OFFER_CONFIGURATIONS);
-            return criteriaBuilder.lessThanOrEqualTo(offerOfferConfigurationJoin.get(PRICE), maxPrice);
         };
     }
 

--- a/src/test/java/com/example/petbuddybackend/service/offer/OfferServiceIntegrationTest.java
+++ b/src/test/java/com/example/petbuddybackend/service/offer/OfferServiceIntegrationTest.java
@@ -87,7 +87,7 @@ public class OfferServiceIntegrationTest {
         );
 
         existingOffer = PersistenceUtils.addComplexOffer(caretakerWithComplexOffer, animalInComplexOffer,
-                animalAttributesInComplexOffer, animalAmenitiesInComplexOffer, offerRepository);
+                animalAttributesInComplexOffer, 10.0, animalAmenitiesInComplexOffer, offerRepository);
 
     }
 

--- a/src/test/java/com/example/petbuddybackend/service/user/CaretakerServiceTest.java
+++ b/src/test/java/com/example/petbuddybackend/service/user/CaretakerServiceTest.java
@@ -122,10 +122,23 @@ public class CaretakerServiceTest {
                         animalAttributeRepository.findByAnimal_AnimalTypeAndAttributeNameAndAttributeValue(
                                 "DOG", "SEX", "MALE").orElseThrow()
                 ),
+                10.0,
                 Arrays.asList(
                         animalAmenityRepository.findByAmenity_NameAndAnimal_AnimalType("toys", "DOG").orElseThrow()
                 ),
                 offerRepository);
+
+        PersistenceUtils.addComplexOffer(
+                caretakerWithComplexOffer,
+                animalRepository.findById("DOG").orElseThrow(),
+                Arrays.asList(
+                        animalAttributeRepository.findByAnimal_AnimalTypeAndAttributeNameAndAttributeValue(
+                                "DOG", "SIZE", "SMALL").orElseThrow()
+                ),
+                90.0,
+                List.of(),
+                offerRepository,
+                caretakerWithComplexOffer.getOffers().get(0));
 
         Page<CaretakerDTO> resultPage = caretakerService.getCaretakers(Pageable.ofSize(10), filters);
 
@@ -350,7 +363,23 @@ public class CaretakerServiceTest {
                                 .minPrice(10.0)
                                 .maxPrice(10.0)
                                 .build()
+                ).build(), 3),
+                Arguments.of(CaretakerSearchCriteria.builder().offerSearchCriteria(
+                        OfferSearchCriteria.builder()
+                                .animalTypes(Set.of("DOG"))
+                                .animalAttributeIds(Set.of(1L))
+                                .minPrice(10.0)
+                                .maxPrice(10.0)
+                                .build()
                 ).build(), 1),
+                Arguments.of(CaretakerSearchCriteria.builder().offerSearchCriteria(
+                        OfferSearchCriteria.builder()
+                                .animalTypes(Set.of("DOG"))
+                                .animalAttributeIds(Set.of(1L))
+                                .minPrice(80.0)
+                                .maxPrice(100.0)
+                                .build()
+                ).build(), 0),
                 Arguments.of(CaretakerSearchCriteria.builder().personalDataLike("doe").build(), 2),
                 Arguments.of(CaretakerSearchCriteria.builder().personalDataLike("testmail").build(), 1),
                 Arguments.of(CaretakerSearchCriteria.builder().personalDataLike("john   doe").build(), 1),

--- a/src/test/java/com/example/petbuddybackend/testutils/MockUtils.java
+++ b/src/test/java/com/example/petbuddybackend/testutils/MockUtils.java
@@ -176,16 +176,16 @@ public final class MockUtils {
                 .build();
     }
 
-    public static OfferConfiguration createOfferConfiguration(Offer offer) {
+    public static OfferConfiguration createOfferConfiguration(Offer offer, Double price) {
         return OfferConfiguration.builder()
                 .description("description")
-                .dailyPrice(10.0)
+                .dailyPrice(price)
                 .offer(offer)
                 .build();
     }
 
     public static OfferConfiguration createOfferConfiguration(Offer offer, List<AnimalAttribute> animalAttributes) {
-        OfferConfiguration offerConfiguration = createOfferConfiguration(offer);
+        OfferConfiguration offerConfiguration = createOfferConfiguration(offer, 10.0);
         List<OfferOption> offerOptions = createOfferOptions(animalAttributes, offerConfiguration);
 
         offerConfiguration.setOfferOptions(new ArrayList<>(offerOptions));
@@ -247,6 +247,7 @@ public final class MockUtils {
     public static Offer createComplexMockOfferForCaretaker(Caretaker caretaker,
                                                           Animal animal,
                                                           List<AnimalAttribute> animalAttributes,
+                                                          Double price,
                                                           List<AnimalAmenity> animalAmenities) {
 
         Offer offer = Offer.builder()
@@ -256,17 +257,61 @@ public final class MockUtils {
                 .build();
 
         if(CollectionUtil.isNotEmpty(animalAttributes)) {
-            OfferConfiguration offerConfiguration = createOfferConfiguration(offer);
+            OfferConfiguration offerConfiguration = createOfferConfiguration(offer, price);
             List<OfferOption> offerOptions = createOfferOptions(animalAttributes, offerConfiguration);
 
             offerConfiguration.setOfferOptions(new ArrayList<>(offerOptions));
-            offer.setOfferConfigurations(new ArrayList<>(List.of(offerConfiguration)));
+            if(CollectionUtil.isNotEmpty(offer.getOfferConfigurations())) {
+                offer.getOfferConfigurations().add(offerConfiguration);
+            } else {
+                offer.setOfferConfigurations(new ArrayList<>(List.of(offerConfiguration)));
+            }
+
         }
         if(CollectionUtil.isNotEmpty(animalAmenities)) {
-            offer.setAnimalAmenities(new HashSet<>(animalAmenities));
+            if(CollectionUtil.isNotEmpty(offer.getAnimalAmenities())) {
+                offer.getAnimalAmenities().addAll(animalAmenities);
+            } else {
+                offer.setAnimalAmenities(new HashSet<>(animalAmenities));
+            }
         }
 
         caretaker.setOffers(new ArrayList<>(List.of(offer)));
+
+        return offer;
+
+    }
+
+    public static Offer createComplexMockOfferForCaretaker(Caretaker caretaker,
+                                                           Animal animal,
+                                                           List<AnimalAttribute> animalAttributes,
+                                                           Double price,
+                                                           List<AnimalAmenity> animalAmenities,
+                                                           Offer offer) {
+
+
+        if(CollectionUtil.isNotEmpty(animalAttributes)) {
+            OfferConfiguration offerConfiguration = createOfferConfiguration(offer, price);
+            List<OfferOption> offerOptions = createOfferOptions(animalAttributes, offerConfiguration);
+
+            offerConfiguration.setOfferOptions(new ArrayList<>(offerOptions));
+            if(CollectionUtil.isNotEmpty(offer.getOfferConfigurations())) {
+                offer.getOfferConfigurations().add(offerConfiguration);
+            } else {
+                offer.setOfferConfigurations(new ArrayList<>(List.of(offerConfiguration)));
+            }
+
+        }
+        if(CollectionUtil.isNotEmpty(animalAmenities)) {
+            if(CollectionUtil.isNotEmpty(offer.getAnimalAmenities())) {
+                offer.getAnimalAmenities().addAll(animalAmenities);
+            } else {
+                offer.setAnimalAmenities(new HashSet<>(animalAmenities));
+            }
+        }
+
+        caretaker.setOffers(new ArrayList<>(List.of(offer)));
+
         return offer;
 
     }

--- a/src/test/java/com/example/petbuddybackend/testutils/PersistenceUtils.java
+++ b/src/test/java/com/example/petbuddybackend/testutils/PersistenceUtils.java
@@ -86,9 +86,16 @@ public class PersistenceUtils {
     }
 
     public static Offer addComplexOffer(Caretaker caretaker, Animal animal, List<AnimalAttribute> animalAttributes,
-                                        List<AnimalAmenity> animalAmenities, OfferRepository offerRepository) {
-        Offer offer = MockUtils.createComplexMockOfferForCaretaker(caretaker, animal, animalAttributes, animalAmenities);
+                                        Double price, List<AnimalAmenity> animalAmenities, OfferRepository offerRepository) {
+        Offer offer = MockUtils.createComplexMockOfferForCaretaker(caretaker, animal, animalAttributes, price, animalAmenities);
         return offerRepository.save(offer);
+    }
+
+    public static Offer addComplexOffer(Caretaker caretaker, Animal animal, List<AnimalAttribute> animalAttributes,
+                                        Double price, List<AnimalAmenity> animalAmenities, OfferRepository offerRepository,
+                                        Offer offer) {
+        Offer offerToSave = MockUtils.createComplexMockOfferForCaretaker(caretaker, animal, animalAttributes, price, animalAmenities, offer);
+        return offerRepository.save(offerToSave);
     }
 
     public static void addOfferConfigurationForOffer(Offer existingOffer, List<AnimalAttribute> animalAttributes, OfferRepository offerRepository) {


### PR DESCRIPTION
Modyfikacja wyszukiwania oferty po konfiguracji zwierzęcia i cenie. Filtruje oferty, aby przynajmniej 1 konfiguracja tej oferty miala atrybut zwierzęcia spośród podanych, np. jeśli szukamy Pies duży samiec, to wystarczy, że w konfiguracji będzie samiec.
Dodatkowo odpowiadająca konfiguracja musi mieścić się w cenie.

Wyszukiwanie oferty jest połączone z wyszukiwaniem opiekunów, więc jednocześnie ma to zastosowanie dla wyszukiwania opiekunów