### PR TITLE
Cyndzer/ZPI-4-ZPI-66-BE-9-BE-41-Wiadomości-odczytane

### DIFF
--- a/src/main/java/com/example/petbuddybackend/controller/ChatController.java
+++ b/src/main/java/com/example/petbuddybackend/controller/ChatController.java
@@ -98,9 +98,9 @@ public class ChatController {
             @RoleParameter @RequestHeader(value = "${header-name.role}") Role acceptRole
     ) {
         return chatService.createChatRoomWithMessage(
-                messageReceiverEmail,
                 principal.getName(),
                 acceptRole,
+                messageReceiverEmail,
                 message,
                 TimeUtils.getOrSystemDefault(acceptTimeZone)
         );

--- a/src/main/java/com/example/petbuddybackend/controller/ChatController.java
+++ b/src/main/java/com/example/petbuddybackend/controller/ChatController.java
@@ -70,19 +70,26 @@ public class ChatController {
                     first step of the communication between a Caretaker and a Client. After this step, websocket 
                     endpoint should be used instead of this endpoint.
                     
-                    **Role header** determines the sender's role in the chat room. If the principal is, for example, 
-                    a Caretaker, the receiver is assumed to be a Client.
-                    
                     ## Connecting to websocket endpoint
                     - To connect to websocket endpoint, use the following path: `/ws`
                     - To subscribe to chat room, use the following path: `/topic/messages/{chatId}`
                     - To send a message to chat room, use the following path: `/app/chat/{chatId}`
                     
                     ## Payload and headers
-                    Same payload and headers apply to websocket endpoint as to this endpoint. Time zone is cached per 
-                    session. It is highly recommended to provide the timezone header when subscribing to the topic.
-                    The header does not have to be provided on each message send, but if it is provided, then the
-                    new timezone will be cached.
+                    **Role header** determines the sender's role in the chat room. If the principal is, for example, 
+                    a Caretaker, the receiver is assumed to be a Client.
+                    
+                    **Time zone** from header is cached per session. It is highly recommended to provide the timezone 
+                    header when subscribing to the topic. The header does not have to be provided on each message send, 
+                    but if it is provided, then the new timezone will be cached.
+                    
+                    The payload is describing the events happening in the chat room. It has a field `type` that determines
+                    the type of the event.
+                    
+                    ## Chat message types
+                    - `MESSAGE` - Used for sending messages. Has field `content` with **ChatMessageDTO**.
+                    - `JOINED` - Used for notifying that user joined the chat room. Has fields `chatId` and `joiningUserEmail`.
+                    - `LEFT` - Used for notifying that user left the chat room. Has fields `chatId` and `leavingUserEmail`.
                     """
     )
     @ApiResponses(value = {
@@ -111,24 +118,31 @@ public class ChatController {
     @Operation(
             summary = "Get all chat rooms",
             description = """
-                          ## Endpoint description
-                          Retrieves a list of all chat rooms for the current user. The returned page is sorted by
-                          the last message timestamp in descending order (from newest to oldest). The chatRoomId can be 
-                          used to connect to the websocket endpoint and send messages to the chat room.
-                          
-                          **Role header** determines the sender's role in the chat room. If the principal is, for example, 
-                          a Caretaker, the receiver is assumed to be a Client.
-                          
-                          ## Connecting to websocket endpoint
-                          - To connect to websocket endpoint, use the following path: `/ws`
-                          - To subscribe to chat room, use the following path: `/topic/messages/{chatId}`
-                          - To send a message to chat room, use the following path: `/app/chat/{chatId}`
-                          
-                          ## Payload and headers
-                          Same payload and headers apply to websocket endpoint as to `/api/chat/{messageReceiverEmail}` 
-                          endpoint. Time zone is cached per session. It is highly recommended to provide the timezone 
-                          header when subscribing to the topic. The header does not have to be provided on each 
-                          message send, but if it is provided, then the new timezone will be cached.
+                        ## Endpoint description
+                        Creates a new chat room with the given user and sends the first message to him. This is the 
+                        first step of the communication between a Caretaker and a Client. After this step, websocket 
+                        endpoint should be used instead of this endpoint.
+                        
+                        ## Connecting to websocket endpoint
+                        - To connect to websocket endpoint, use the following path: `/ws`
+                        - To subscribe to chat room, use the following path: `/topic/messages/{chatId}`
+                        - To send a message to chat room, use the following path: `/app/chat/{chatId}`
+                        
+                        ## Payload and headers
+                        **Role header** determines the sender's role in the chat room. If the principal is, for example, 
+                        a Caretaker, the receiver is assumed to be a Client.
+                        
+                        **Time zone** from header is cached per session. It is highly recommended to provide the timezone 
+                        header when subscribing to the topic. The header does not have to be provided on each message send, 
+                        but if it is provided, then the new timezone will be cached.
+                        
+                        The payload is describing the events happening in the chat room. It has a field `type` that determines
+                        the type of the event.
+                        
+                        ## Chat message types
+                        - `MESSAGE` - Used for sending messages. Has field `content` with **ChatMessageDTO**.
+                        - `JOINED` - Used for notifying that user joined the chat room. Has fields `chatId` and `joiningUserEmail`.
+                        - `LEFT` - Used for notifying that user left the chat room. Has fields `chatId` and `leavingUserEmail`.
                           """
     )
     public Page<ChatRoomDTO> getChatRooms(

--- a/src/main/java/com/example/petbuddybackend/controller/ChatController.java
+++ b/src/main/java/com/example/petbuddybackend/controller/ChatController.java
@@ -51,7 +51,7 @@ public class ChatController {
             @TimeZoneParameter @RequestHeader(value = "${header-name.timezone}", required = false) String acceptTimeZone
     ) {
         Pageable pageable = PagingUtils.createPageable(pagingParams);
-        return chatService.getChatMessages(
+        return chatService.getChatMessagesByParticipantEmail(
                 chatId,
                 principal.getName(),
                 pageable,

--- a/src/main/java/com/example/petbuddybackend/controller/ChatWebSocketController.java
+++ b/src/main/java/com/example/petbuddybackend/controller/ChatWebSocketController.java
@@ -2,6 +2,9 @@ package com.example.petbuddybackend.controller;
 
 import com.example.petbuddybackend.dto.chat.ChatMessageDTO;
 import com.example.petbuddybackend.dto.chat.ChatMessageSent;
+import com.example.petbuddybackend.dto.chat.notification.ChatNotificationJoined;
+import com.example.petbuddybackend.dto.chat.notification.ChatNotificationLeft;
+import com.example.petbuddybackend.dto.chat.notification.ChatNotificationMessage;
 import com.example.petbuddybackend.entity.user.Role;
 import com.example.petbuddybackend.service.chat.ChatService;
 import com.example.petbuddybackend.service.chat.session.ChatSessionService;
@@ -50,7 +53,7 @@ public class ChatWebSocketController {
         MessageCallback callback = chatService.createCallbackMessageSeen(chatId, principalUsername);
 
         chatSessionService.patchMetadata(chatId, principalUsername, headers);
-        chatSessionService.sendMessages(chatId, messageDTO, callback);
+        chatSessionService.sendNotifications(chatId, new ChatNotificationMessage(messageDTO), callback);
     }
 
     @EventListener
@@ -62,6 +65,7 @@ public class ChatWebSocketController {
 
         chatService.updateLastMessageSeen(chatId, username);
         chatSessionService.subscribeIfAbsent(chatId, username, timeZone);
+        chatSessionService.sendNotifications(chatId, new ChatNotificationJoined(chatId, username));
     }
 
     @EventListener
@@ -71,5 +75,6 @@ public class ChatWebSocketController {
         Long chatId = HeaderUtils.getLongFromDestination(accessor, CHAT_ID_INDEX_IN_TOPIC_URL);
 
         chatSessionService.unsubscribeIfPresent(chatId, username);
+        chatSessionService.sendNotifications(chatId, new ChatNotificationLeft(chatId, username));
     }
 }

--- a/src/main/java/com/example/petbuddybackend/dto/chat/ChatMessageDTO.java
+++ b/src/main/java/com/example/petbuddybackend/dto/chat/ChatMessageDTO.java
@@ -20,4 +20,5 @@ public class ChatMessageDTO {
         private String content;
         @JsonFormat(pattern = TimeUtils.ZONED_DATETIME_FORMAT)
         private ZonedDateTime createdAt;
+        private boolean seenByRecipient;
 }

--- a/src/main/java/com/example/petbuddybackend/dto/chat/ChatMessageDTO.java
+++ b/src/main/java/com/example/petbuddybackend/dto/chat/ChatMessageDTO.java
@@ -20,5 +20,5 @@ public class ChatMessageDTO {
         private String content;
         @JsonFormat(pattern = TimeUtils.ZONED_DATETIME_FORMAT)
         private ZonedDateTime createdAt;
-        private boolean seenByRecipient;
+        private Boolean seenByRecipient;
 }

--- a/src/main/java/com/example/petbuddybackend/dto/chat/ChatMessageSent.java
+++ b/src/main/java/com/example/petbuddybackend/dto/chat/ChatMessageSent.java
@@ -1,7 +1,7 @@
 package com.example.petbuddybackend.dto.chat;
 
-import jakarta.validation.constraints.Max;
 import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
 import lombok.AllArgsConstructor;
 import lombok.Data;
 import lombok.NoArgsConstructor;
@@ -10,6 +10,7 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor
 @AllArgsConstructor
 public class ChatMessageSent {
-    @NotBlank @Max(4000)
+    @NotBlank
+    @Size(max = 4000)
     private String content;
 }

--- a/src/main/java/com/example/petbuddybackend/dto/chat/ChatMessageSent.java
+++ b/src/main/java/com/example/petbuddybackend/dto/chat/ChatMessageSent.java
@@ -1,5 +1,6 @@
 package com.example.petbuddybackend.dto.chat;
 
+import jakarta.validation.constraints.Max;
 import jakarta.validation.constraints.NotBlank;
 import lombok.AllArgsConstructor;
 import lombok.Data;
@@ -9,6 +10,6 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor
 @AllArgsConstructor
 public class ChatMessageSent {
-    @NotBlank
+    @NotBlank @Max(4000)
     private String content;
 }

--- a/src/main/java/com/example/petbuddybackend/dto/chat/ChatRoomDTO.java
+++ b/src/main/java/com/example/petbuddybackend/dto/chat/ChatRoomDTO.java
@@ -22,4 +22,5 @@ public class ChatRoomDTO {
     private ZonedDateTime lastMessageCreatedAt;
     private String lastMessage;
     private String lastMessageSendBy;
+    private Boolean seen;
 }

--- a/src/main/java/com/example/petbuddybackend/dto/chat/ChatRoomDTO.java
+++ b/src/main/java/com/example/petbuddybackend/dto/chat/ChatRoomDTO.java
@@ -22,5 +22,5 @@ public class ChatRoomDTO {
     private ZonedDateTime lastMessageCreatedAt;
     private String lastMessage;
     private String lastMessageSendBy;
-    private Boolean seen;
+    private Boolean seenByPrincipal;
 }

--- a/src/main/java/com/example/petbuddybackend/dto/chat/notification/ChatNotification.java
+++ b/src/main/java/com/example/petbuddybackend/dto/chat/notification/ChatNotification.java
@@ -1,0 +1,12 @@
+package com.example.petbuddybackend.dto.chat.notification;
+
+import lombok.*;
+
+@Getter
+@ToString
+@EqualsAndHashCode
+@AllArgsConstructor
+@NoArgsConstructor
+public abstract class ChatNotification {
+    private ChatNotificationType type;
+}

--- a/src/main/java/com/example/petbuddybackend/dto/chat/notification/ChatNotificationJoined.java
+++ b/src/main/java/com/example/petbuddybackend/dto/chat/notification/ChatNotificationJoined.java
@@ -2,9 +2,11 @@ package com.example.petbuddybackend.dto.chat.notification;
 
 import lombok.Data;
 import lombok.EqualsAndHashCode;
+import lombok.NoArgsConstructor;
 
 @Data
 @EqualsAndHashCode(callSuper = true)
+@NoArgsConstructor
 public class ChatNotificationJoined extends ChatNotification {
 
     private Long chatId;

--- a/src/main/java/com/example/petbuddybackend/dto/chat/notification/ChatNotificationJoined.java
+++ b/src/main/java/com/example/petbuddybackend/dto/chat/notification/ChatNotificationJoined.java
@@ -1,0 +1,18 @@
+package com.example.petbuddybackend.dto.chat.notification;
+
+import lombok.Data;
+import lombok.EqualsAndHashCode;
+
+@Data
+@EqualsAndHashCode(callSuper = true)
+public class ChatNotificationJoined extends ChatNotification {
+
+    private Long chatId;
+    private String joiningUserEmail;
+
+    public ChatNotificationJoined(Long chatId, String userEmail) {
+        super(ChatNotificationType.JOINED);
+        this.chatId = chatId;
+        this.joiningUserEmail = userEmail;
+    }
+}

--- a/src/main/java/com/example/petbuddybackend/dto/chat/notification/ChatNotificationLeft.java
+++ b/src/main/java/com/example/petbuddybackend/dto/chat/notification/ChatNotificationLeft.java
@@ -1,0 +1,18 @@
+package com.example.petbuddybackend.dto.chat.notification;
+
+import lombok.Data;
+import lombok.EqualsAndHashCode;
+
+@Data
+@EqualsAndHashCode(callSuper = true)
+public class ChatNotificationLeft extends ChatNotification {
+
+    private Long chatId;
+    private String leavingUserEmail;
+
+    public ChatNotificationLeft(Long chatId, String userEmail) {
+        super(ChatNotificationType.LEFT);
+        this.chatId = chatId;
+        this.leavingUserEmail = userEmail;
+    }
+}

--- a/src/main/java/com/example/petbuddybackend/dto/chat/notification/ChatNotificationLeft.java
+++ b/src/main/java/com/example/petbuddybackend/dto/chat/notification/ChatNotificationLeft.java
@@ -2,9 +2,11 @@ package com.example.petbuddybackend.dto.chat.notification;
 
 import lombok.Data;
 import lombok.EqualsAndHashCode;
+import lombok.NoArgsConstructor;
 
 @Data
 @EqualsAndHashCode(callSuper = true)
+@NoArgsConstructor
 public class ChatNotificationLeft extends ChatNotification {
 
     private Long chatId;

--- a/src/main/java/com/example/petbuddybackend/dto/chat/notification/ChatNotificationMessage.java
+++ b/src/main/java/com/example/petbuddybackend/dto/chat/notification/ChatNotificationMessage.java
@@ -1,0 +1,20 @@
+package com.example.petbuddybackend.dto.chat.notification;
+
+import com.example.petbuddybackend.dto.chat.ChatMessageDTO;
+import lombok.Data;
+import lombok.EqualsAndHashCode;
+import lombok.NoArgsConstructor;
+
+@Data
+@EqualsAndHashCode(callSuper = true)
+@NoArgsConstructor
+public class ChatNotificationMessage extends ChatNotification {
+
+    private ChatMessageDTO content;
+
+    public ChatNotificationMessage(ChatMessageDTO chatMessage) {
+        super(ChatNotificationType.MESSAGE);
+        this.content = chatMessage;
+    }
+}
+

--- a/src/main/java/com/example/petbuddybackend/dto/chat/notification/ChatNotificationType.java
+++ b/src/main/java/com/example/petbuddybackend/dto/chat/notification/ChatNotificationType.java
@@ -1,0 +1,5 @@
+package com.example.petbuddybackend.dto.chat.notification;
+
+public enum ChatNotificationType {
+    JOINED, LEFT, MESSAGE
+}

--- a/src/main/java/com/example/petbuddybackend/entity/chat/ChatMessage.java
+++ b/src/main/java/com/example/petbuddybackend/entity/chat/ChatMessage.java
@@ -31,6 +31,22 @@ public class ChatMessage {
     @JoinColumn(name = "senderEmail", referencedColumnName = "email")
     private AppUser sender;
 
+    @Transient
+    public boolean isSeenByRecipient() {
+        AppUser clientAccountData = chatRoom.getClient().getAccountData();
+        AppUser caretakerAccountData = chatRoom.getCaretaker().getAccountData();
+
+        if(sender.equals(clientAccountData)) {
+            ChatMessage lastSeenByCaretaker = chatRoom.getLastMessageSeenByCaretaker();
+            return lastSeenByCaretaker != null && !lastSeenByCaretaker.getCreatedAt().isBefore(createdAt);
+        } else if(sender.equals(caretakerAccountData)) {
+            ChatMessage lastSeenByClient = chatRoom.getLastMessageSeenByClient();
+            return lastSeenByClient != null && !lastSeenByClient.getCreatedAt().isBefore(createdAt);
+        }
+
+        return false;
+    }
+
     @PrePersist
     public void prePersist() {
         if (createdAt == null) {

--- a/src/main/java/com/example/petbuddybackend/entity/chat/ChatMessage.java
+++ b/src/main/java/com/example/petbuddybackend/entity/chat/ChatMessage.java
@@ -31,26 +31,17 @@ public class ChatMessage {
     @JoinColumn(name = "senderEmail", referencedColumnName = "email")
     private AppUser sender;
 
-    @Transient
-    public boolean isSeenByRecipient() {
-        AppUser clientAccountData = chatRoom.getClient().getAccountData();
-        AppUser caretakerAccountData = chatRoom.getCaretaker().getAccountData();
-
-        if(sender.equals(clientAccountData)) {
-            ChatMessage lastSeenByCaretaker = chatRoom.getLastMessageSeenByCaretaker();
-            return lastSeenByCaretaker != null && !lastSeenByCaretaker.getCreatedAt().isBefore(createdAt);
-        } else if(sender.equals(caretakerAccountData)) {
-            ChatMessage lastSeenByClient = chatRoom.getLastMessageSeenByClient();
-            return lastSeenByClient != null && !lastSeenByClient.getCreatedAt().isBefore(createdAt);
-        }
-
-        return false;
-    }
+    @Column(nullable = false)
+    private Boolean seenByRecipient = false;
 
     @PrePersist
     public void prePersist() {
         if (createdAt == null) {
             createdAt = ZonedDateTime.now();
+        }
+
+        if (seenByRecipient == null) {
+            seenByRecipient = false;
         }
     }
 }

--- a/src/main/java/com/example/petbuddybackend/entity/chat/ChatRoom.java
+++ b/src/main/java/com/example/petbuddybackend/entity/chat/ChatRoom.java
@@ -5,7 +5,6 @@ import com.example.petbuddybackend.entity.user.Client;
 import jakarta.persistence.*;
 import lombok.*;
 import org.hibernate.annotations.Check;
-import org.hibernate.annotations.Formula;
 
 import java.util.List;
 
@@ -35,14 +34,4 @@ public class ChatRoom {
 
     @OneToMany(mappedBy = "chatRoom", cascade = CascadeType.ALL, fetch = FetchType.LAZY, orphanRemoval = true)
     private List<ChatMessage> messages;
-
-    @Basic(fetch = FetchType.LAZY)
-    @Formula("(SELECT cm.id FROM chat_message cm WHERE cm.chat_room_id = id ORDER BY cm.created_at DESC LIMIT 1)")
-    private Long lastMessageId;
-
-    @OneToOne(fetch = FetchType.LAZY)
-    private ChatMessage lastMessageSeenByClient;
-
-    @OneToOne(fetch = FetchType.LAZY)
-    private ChatMessage lastMessageSeenByCaretaker;
 }

--- a/src/main/java/com/example/petbuddybackend/entity/chat/ChatRoom.java
+++ b/src/main/java/com/example/petbuddybackend/entity/chat/ChatRoom.java
@@ -5,6 +5,7 @@ import com.example.petbuddybackend.entity.user.Client;
 import jakarta.persistence.*;
 import lombok.*;
 import org.hibernate.annotations.Check;
+import org.hibernate.annotations.Formula;
 
 import java.util.List;
 
@@ -34,4 +35,14 @@ public class ChatRoom {
 
     @OneToMany(mappedBy = "chatRoom", cascade = CascadeType.ALL, fetch = FetchType.LAZY, orphanRemoval = true)
     private List<ChatMessage> messages;
+
+    @Basic(fetch = FetchType.LAZY)
+    @Formula("(SELECT cm.id FROM chat_message cm WHERE cm.chat_room_id = id ORDER BY cm.created_at DESC LIMIT 1)")
+    private Long lastMessageId;
+
+    @OneToOne(fetch = FetchType.LAZY)
+    private ChatMessage lastMessageSeenByClient;
+
+    @OneToOne(fetch = FetchType.LAZY)
+    private ChatMessage lastMessageSeenByCaretaker;
 }

--- a/src/main/java/com/example/petbuddybackend/repository/chat/ChatMessageRepository.java
+++ b/src/main/java/com/example/petbuddybackend/repository/chat/ChatMessageRepository.java
@@ -5,9 +5,11 @@ import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.Optional;
+
 public interface ChatMessageRepository extends JpaRepository<ChatMessage, Long> {
 
     Page<ChatMessage> findByChatRoom_Id_OrderByCreatedAtDesc(Long chatId, Pageable pageable);
 
-    ChatMessage findFirstByChatRoom_IdOrderByCreatedAtDesc(Long id);
+    Optional<ChatMessage> findFirstByChatRoom_IdOrderByCreatedAtDesc(Long id);
 }

--- a/src/main/java/com/example/petbuddybackend/repository/chat/ChatMessageRepository.java
+++ b/src/main/java/com/example/petbuddybackend/repository/chat/ChatMessageRepository.java
@@ -4,12 +4,30 @@ import com.example.petbuddybackend.entity.chat.ChatMessage;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
-
-import java.util.Optional;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
 
 public interface ChatMessageRepository extends JpaRepository<ChatMessage, Long> {
 
     Page<ChatMessage> findByChatRoom_Id_OrderByCreatedAtDesc(Long chatId, Pageable pageable);
 
-    Optional<ChatMessage> findFirstByChatRoom_IdOrderByCreatedAtDesc(Long id);
+    @Modifying
+    @Query("""
+        UPDATE ChatMessage m
+        SET m.seenByRecipient = true
+        WHERE m.chatRoom.id = :chatRoomId
+          AND m.seenByRecipient = false
+          AND m.sender.email != :caretakerEmail
+        """)
+    void updateUnseenMessagesOfCaretaker(Long chatRoomId, String caretakerEmail);
+
+    @Modifying
+    @Query("""
+        UPDATE ChatMessage m
+        SET m.seenByRecipient = true
+        WHERE m.chatRoom.id = :chatRoomId
+          AND m.seenByRecipient = false
+          AND m.sender.email != :clientEmail
+        """)
+    void updateUnseenMessagesOfClient(Long chatRoomId, String clientEmail);
 }

--- a/src/main/java/com/example/petbuddybackend/repository/chat/ChatRoomRepository.java
+++ b/src/main/java/com/example/petbuddybackend/repository/chat/ChatRoomRepository.java
@@ -18,37 +18,53 @@ public interface ChatRoomRepository extends JpaRepository<ChatRoom, Long> {
 
     @Query("""
         SELECT new com.example.petbuddybackend.dto.chat.ChatRoomDTO(
-            cr.id,
-            cr.caretaker.email,
-            cr.caretaker.accountData.name,
-            cr.caretaker.accountData.surname,
-            cm.createdAt,
-            cm.content,
-            cm.sender.email,
-            (lmsbc IS NOT NULL AND lmsbc.createdAt >= cm.createdAt)
+               cr.id,
+               cr.caretaker.email,
+               cr.caretaker.accountData.name,
+               cr.caretaker.accountData.surname,
+               cm.createdAt,
+               cm.content,
+               cm.sender.email,
+               CASE WHEN cm.sender.email = cr.client.email THEN true ELSE cm.seenByRecipient END
         )
         FROM ChatRoom cr
-        JOIN ChatMessage cm ON cr.lastMessageId = cm.id
-        LEFT JOIN ChatMessage lmsbc ON lmsbc.id = cr.lastMessageSeenByClient.id
+        JOIN ChatMessage cm ON cm.chatRoom.id = cr.id
         WHERE cr.client.email = :email
+        AND cm.id = (
+            SELECT MIN(cm2.id)
+            FROM ChatMessage cm2
+            WHERE cm2.createdAt = (
+                SELECT MAX(cm3.createdAt)
+                FROM ChatMessage cm3
+                WHERE cm3.chatRoom.id = cr.id
+            ) AND cm2.chatRoom.id = cr.id
+        )
         """)
     Page<ChatRoomDTO> findByClientEmailSortByLastMessageDesc(String email, Pageable pageable);
 
     @Query("""
         SELECT new com.example.petbuddybackend.dto.chat.ChatRoomDTO(
-            cr.id,
-            cr.client.email,
-            cr.client.accountData.name,
-            cr.client.accountData.surname,
-            cm.createdAt,
-            cm.content,
-            cm.sender.email,
-            (lmsbc IS NOT NULL AND lmsbc.createdAt >= cm.createdAt)
+               cr.id,
+               cr.client.email,
+               cr.client.accountData.name,
+               cr.client.accountData.surname,
+               cm.createdAt,
+               cm.content,
+               cm.sender.email,
+               CASE WHEN cm.sender.email = cr.caretaker.email THEN true ELSE cm.seenByRecipient END
         )
         FROM ChatRoom cr
-        JOIN ChatMessage cm ON cr.lastMessageId = cm.id
-        LEFT JOIN ChatMessage lmsbc ON lmsbc.id = cr.lastMessageSeenByCaretaker.id
+        JOIN ChatMessage cm ON cm.chatRoom.id = cr.id
         WHERE cr.caretaker.email = :email
+        AND cm.id = (
+            SELECT MIN(cm2.id)
+            FROM ChatMessage cm2
+            WHERE cm2.createdAt = (
+                SELECT MAX(cm3.createdAt)
+                FROM ChatMessage cm3
+                WHERE cm3.chatRoom.id = cr.id
+            ) AND cm2.chatRoom.id = cr.id
+        )
         """)
     Page<ChatRoomDTO> findByCaretakerEmailSortByLastMessageDesc(String email, Pageable pageable);
 }

--- a/src/main/java/com/example/petbuddybackend/repository/chat/ChatRoomRepository.java
+++ b/src/main/java/com/example/petbuddybackend/repository/chat/ChatRoomRepository.java
@@ -18,51 +18,37 @@ public interface ChatRoomRepository extends JpaRepository<ChatRoom, Long> {
 
     @Query("""
         SELECT new com.example.petbuddybackend.dto.chat.ChatRoomDTO(
-               cr.id,
-               cr.client.email,
-               cr.client.accountData.name,
-               cr.client.accountData.surname,
-               cm.createdAt,
-               cm.content,
-               cm.sender.email
+            cr.id,
+            cr.caretaker.email,
+            cr.caretaker.accountData.name,
+            cr.caretaker.accountData.surname,
+            cm.createdAt,
+            cm.content,
+            cm.sender.email,
+            (lmsbc IS NOT NULL AND lmsbc.createdAt >= cm.createdAt)
         )
         FROM ChatRoom cr
-        JOIN ChatMessage cm ON cm.chatRoom.id = cr.id
-        WHERE cr.caretaker.email = :email
-        AND cm.id = (
-            SELECT MIN(cm2.id)
-            FROM ChatMessage cm2
-            WHERE cm2.createdAt = (
-                SELECT MAX(cm3.createdAt)
-                FROM ChatMessage cm3
-                WHERE cm3.chatRoom.id = cr.id
-            ) AND cm2.chatRoom.id = cr.id
-        )
+        JOIN ChatMessage cm ON cr.lastMessageId = cm.id
+        LEFT JOIN ChatMessage lmsbc ON lmsbc.id = cr.lastMessageSeenByClient.id
+        WHERE cr.client.email = :email
         """)
-    Page<ChatRoomDTO> findByCaretakerEmailSortByLastMessageDesc(String email, Pageable pageable);
+    Page<ChatRoomDTO> findByClientEmailSortByLastMessageDesc(String email, Pageable pageable);
 
     @Query("""
         SELECT new com.example.petbuddybackend.dto.chat.ChatRoomDTO(
-               cr.id,
-               cr.caretaker.email,
-               cr.caretaker.accountData.name,
-               cr.caretaker.accountData.surname,
-               cm.createdAt,
-               cm.content,
-               cm.sender.email
+            cr.id,
+            cr.client.email,
+            cr.client.accountData.name,
+            cr.client.accountData.surname,
+            cm.createdAt,
+            cm.content,
+            cm.sender.email,
+            (lmsbc IS NOT NULL AND lmsbc.createdAt >= cm.createdAt)
         )
         FROM ChatRoom cr
-        JOIN ChatMessage cm ON cm.chatRoom.id = cr.id
-        WHERE cr.client.email = :email
-        AND cm.id = (
-            SELECT MIN(cm2.id)
-            FROM ChatMessage cm2
-            WHERE cm2.createdAt = (
-                SELECT MAX(cm3.createdAt)
-                FROM ChatMessage cm3
-                WHERE cm3.chatRoom.id = cr.id
-            ) AND cm2.chatRoom.id = cr.id
-        ) 
+        JOIN ChatMessage cm ON cr.lastMessageId = cm.id
+        LEFT JOIN ChatMessage lmsbc ON lmsbc.id = cr.lastMessageSeenByCaretaker.id
+        WHERE cr.caretaker.email = :email
         """)
-    Page<ChatRoomDTO> findByClientEmailSortByLastMessageDesc(String email, Pageable pageable);
+    Page<ChatRoomDTO> findByCaretakerEmailSortByLastMessageDesc(String email, Pageable pageable);
 }

--- a/src/main/java/com/example/petbuddybackend/service/chat/ChatService.java
+++ b/src/main/java/com/example/petbuddybackend/service/chat/ChatService.java
@@ -49,7 +49,7 @@ public class ChatService {
             Pageable pageable,
             ZoneId timeZone
     ) {
-        checkChatExistsById(chatId);
+        checkChatExists(chatId);
         checkUserInChat(chatId, principalEmail);
 
         Page<ChatMessage> chatMessages = chatMessageRepository.findByChatRoom_Id_OrderByCreatedAtDesc(chatId, pageable);
@@ -118,7 +118,9 @@ public class ChatService {
     /**
      * Updates the last message seen by the user in the chat room to the latest message in the chat room.
      * */
+    @Transactional
     public void updateLastMessageSeen(Long chatId, String email) {
+        checkChatExists(chatId);
         Role userRole = getRoleOfUserInChat(chatId, email);
 
         if(userRole == Role.CLIENT) {
@@ -206,7 +208,7 @@ public class ChatService {
         return chatRepository.save(chatRoom);
     }
 
-    private void checkChatExistsById(Long chatId) {
+    private void checkChatExists(Long chatId) {
         if(!chatRepository.existsById(chatId)) {
             throw NotFoundException.withFormattedMessage(CHAT, chatId.toString());
         }

--- a/src/main/java/com/example/petbuddybackend/service/chat/ChatService.java
+++ b/src/main/java/com/example/petbuddybackend/service/chat/ChatService.java
@@ -52,8 +52,9 @@ public class ChatService {
         checkChatExists(chatId);
         checkUserInChat(chatId, principalEmail);
 
-        Page<ChatMessage> chatMessages = chatMessageRepository.findByChatRoom_Id_OrderByCreatedAtDesc(chatId, pageable);
-        return chatMessages.map(message -> chatMapper.mapToChatMessageDTO(message, timeZone));
+        return chatMessageRepository
+                .findByChatRoom_Id_OrderByCreatedAtDesc(chatId, pageable)
+                .map(message -> chatMapper.mapToChatMessageDTO(message, timeZone));
     }
 
     public ChatRoom getChatRoomById(Long chatId) {
@@ -130,6 +131,7 @@ public class ChatService {
         }
     }
 
+    @Transactional
     public MessageCallback createCallbackMessageSeen(Long chatId, String usernameToSkip) {
         return usernameSend -> {
             if(!usernameSend.equals(usernameToSkip)) {

--- a/src/main/java/com/example/petbuddybackend/service/chat/ChatService.java
+++ b/src/main/java/com/example/petbuddybackend/service/chat/ChatService.java
@@ -23,6 +23,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 import java.time.ZoneId;
 
@@ -76,6 +77,7 @@ public class ChatService {
     /**
      * Creates a message in the chat room with the given id and updates the last message seen by the user in the chat room.
      * */
+    @Transactional
     public ChatMessageDTO createMessage(
             Long chatId,
             String principalEmail,
@@ -86,6 +88,7 @@ public class ChatService {
         return chatMapper.mapToChatMessageDTO(message);
     }
 
+    @Transactional
     public ChatMessageDTO createChatRoomWithMessage(
             String principalEmail,
             Role principalRole,

--- a/src/main/java/com/example/petbuddybackend/service/chat/session/ChatSessionService.java
+++ b/src/main/java/com/example/petbuddybackend/service/chat/session/ChatSessionService.java
@@ -55,12 +55,14 @@ public class ChatSessionService {
     }
 
     public void subscribe(Long chatId, String username, String timeZone) {
-        sessionContext.setChatId(chatId);
-        sessionContext.setUsername(username);
-        sessionContext.setCleanupCallback(chatSessionManager::remove);
-
+        sessionContext.setContext(chatId, username, chatSessionManager::remove);
         ChatUserMetadata metadata = new ChatUserMetadata(username, TimeUtils.getOrSystemDefault(timeZone));
         chatSessionManager.putIfAbsent(chatId, metadata);
+    }
+
+    public void unsubscribe(Long chatId, String username) {
+        sessionContext.clearContext();
+        chatSessionManager.remove(chatId, username);
     }
 
     private void executeSendNotificationConvertTimeZone(

--- a/src/main/java/com/example/petbuddybackend/service/chat/session/ChatSessionService.java
+++ b/src/main/java/com/example/petbuddybackend/service/chat/session/ChatSessionService.java
@@ -1,8 +1,8 @@
 package com.example.petbuddybackend.service.chat.session;
 
-import com.example.petbuddybackend.dto.chat.ChatMessageDTO;
 import com.example.petbuddybackend.dto.chat.notification.ChatNotification;
 import com.example.petbuddybackend.dto.chat.notification.ChatNotificationMessage;
+import com.example.petbuddybackend.service.chat.session.context.ChatSessionContext;
 import com.example.petbuddybackend.service.mapper.ChatMapper;
 import com.example.petbuddybackend.utils.header.HeaderUtils;
 import com.example.petbuddybackend.utils.time.TimeUtils;
@@ -27,20 +27,25 @@ public class ChatSessionService {
     private final SimpMessagingTemplate simpMessagingTemplate;
     private final ChatSessionManager chatSessionManager;
     private final ChatMapper chatMapper = ChatMapper.INSTANCE;
+    private final ChatSessionContext sessionContext;
+
+    public ChatSessionContext getContext() {
+        return sessionContext;
+    }
 
     public void sendNotifications(Long chatId, ChatNotification notification, MessageCallback callback) {
         switch(notification.getType()) {
             case MESSAGE:
-                sendNotificationConvertTimeZone((ChatNotificationMessage) notification, chatId, callback);
+                executeSendNotificationConvertTimeZone((ChatNotificationMessage) notification, chatId, callback);
                 break;
             case JOINED, LEFT:
-                sendNotification(notification, chatId, callback);
+                executeSendNotification(notification, chatId, callback);
                 break;
         }
     }
 
     public void sendNotifications(Long chatId, ChatNotification notification) {
-        sendNotification(notification, chatId, username -> {});
+        sendNotifications(chatId, notification, username -> {});
     }
 
     public void patchMetadata(Long chatId, String username, Map<String, Object> headers) {
@@ -49,33 +54,42 @@ public class ChatSessionService {
         timeZone.ifPresent(s -> metadata.setZoneId(TimeUtils.get(s)));
     }
 
-    public void subscribeIfAbsent(Long chatId, String username, String timeZone) {
+    public void subscribe(Long chatId, String username, String timeZone) {
+        sessionContext.setChatId(chatId);
+        sessionContext.setUsername(username);
+        sessionContext.setCleanupCallback(chatSessionManager::remove);
+
         ChatUserMetadata metadata = new ChatUserMetadata(username, TimeUtils.getOrSystemDefault(timeZone));
         chatSessionManager.putIfAbsent(chatId, metadata);
     }
 
-    public void unsubscribeIfPresent(Long chatId, String username) {
-        chatSessionManager.remove(chatId, username);
-    }
-
-    private void sendNotificationConvertTimeZone(ChatNotificationMessage notification, Long chatId, MessageCallback callback) {
+    private void executeSendNotificationConvertTimeZone(
+            ChatNotificationMessage notification,
+            Long chatId,
+            MessageCallback callback
+    ) {
         chatSessionManager.get(chatId).forEach(userMetadata -> {
             String username = userMetadata.getUsername();
-            String destination = String.format(SUBSCRIPTION_URL_PATTERN, chatId, username);
-            ChatMessageDTO messageDTOConverted = chatMapper.mapTimeZone(notification.getContent(), userMetadata.getZoneId());
 
-            simpMessagingTemplate.convertAndSend(destination, messageDTOConverted);
+            notification.setContent(
+                    chatMapper.mapTimeZone(notification.getContent(), userMetadata.getZoneId())
+            );
+
+            simpMessagingTemplate.convertAndSend(formatDestination(chatId, username), notification);
             callback.onMessageSent(username);
         });
     }
 
-    private void sendNotification(ChatNotification notification, Long chatId,  MessageCallback callback) {
+    private void executeSendNotification(ChatNotification notification, Long chatId, MessageCallback callback) {
         chatSessionManager.get(chatId).forEach(userMetadata -> {
             String username = userMetadata.getUsername();
-            String destination = String.format(SUBSCRIPTION_URL_PATTERN, chatId, username);
 
-            simpMessagingTemplate.convertAndSend(destination, notification);
+            simpMessagingTemplate.convertAndSend(formatDestination(chatId, username), notification);
             callback.onMessageSent(username);
         });
+    }
+
+    private String formatDestination(Long chatId, String username) {
+        return String.format(SUBSCRIPTION_URL_PATTERN, chatId, username);
     }
 }

--- a/src/main/java/com/example/petbuddybackend/service/chat/session/MessageCallback.java
+++ b/src/main/java/com/example/petbuddybackend/service/chat/session/MessageCallback.java
@@ -1,0 +1,6 @@
+package com.example.petbuddybackend.service.chat.session;
+
+@FunctionalInterface
+public interface MessageCallback {
+    void onMessageSent(String username);
+}

--- a/src/main/java/com/example/petbuddybackend/service/chat/session/context/ChatSessionContext.java
+++ b/src/main/java/com/example/petbuddybackend/service/chat/session/context/ChatSessionContext.java
@@ -6,34 +6,48 @@ import org.springframework.context.annotation.Scope;
 import org.springframework.context.annotation.ScopedProxyMode;
 import org.springframework.stereotype.Component;
 
-@Data
+@ToString
+@Getter
+@EqualsAndHashCode
 @Component
 @Scope(scopeName = "websocket", proxyMode = ScopedProxyMode.TARGET_CLASS)
-@AllArgsConstructor
 public class ChatSessionContext implements DisposableBean {
 
     private Long chatId;
     private String username;
-    private boolean userPresent;
     private ContextCleanupCallback cleanupCallback;
+    private boolean empty;
 
     public ChatSessionContext() {
         this.chatId = null;
         this.username = null;
-        this.userPresent = true;
+        this.empty = false;
         this.cleanupCallback = (chatId, username) -> {};
+    }
+
+    public ChatSessionContext(Long chatId, String username, ContextCleanupCallback cleanupCallback) {
+        this.chatId = chatId;
+        this.username = username;
+        this.cleanupCallback = cleanupCallback;
+        this.empty = false;
     }
 
     @Override
     public void destroy() {
-        if(chatId == null || username == null) {
-            return;
-        }
-
         cleanupCallback.onDestroy(chatId, username);
     }
 
-    public boolean isEmpty() {
-        return chatId == null && username == null;
+    public void clearContext() {
+        this.empty = true;
+        this.username = null;
+        this.chatId = null;
+        this.cleanupCallback = (id, username) -> {};
+    }
+
+    public void setContext(Long chatId, String username, ContextCleanupCallback cleanupCallback) {
+        this.empty = false;
+        this.username = username;
+        this.chatId = chatId;
+        this.cleanupCallback = cleanupCallback;
     }
 }

--- a/src/main/java/com/example/petbuddybackend/service/chat/session/context/ChatSessionContext.java
+++ b/src/main/java/com/example/petbuddybackend/service/chat/session/context/ChatSessionContext.java
@@ -1,0 +1,39 @@
+package com.example.petbuddybackend.service.chat.session.context;
+
+import lombok.*;
+import org.springframework.beans.factory.DisposableBean;
+import org.springframework.context.annotation.Scope;
+import org.springframework.context.annotation.ScopedProxyMode;
+import org.springframework.stereotype.Component;
+
+@Data
+@Component
+@Scope(scopeName = "websocket", proxyMode = ScopedProxyMode.TARGET_CLASS)
+@AllArgsConstructor
+public class ChatSessionContext implements DisposableBean {
+
+    private Long chatId;
+    private String username;
+    private boolean userPresent;
+    private ContextCleanupCallback cleanupCallback;
+
+    public ChatSessionContext() {
+        this.chatId = null;
+        this.username = null;
+        this.userPresent = true;
+        this.cleanupCallback = (chatId, username) -> {};
+    }
+
+    @Override
+    public void destroy() {
+        if(chatId == null || username == null) {
+            return;
+        }
+
+        cleanupCallback.onDestroy(chatId, username);
+    }
+
+    public boolean isEmpty() {
+        return chatId == null && username == null;
+    }
+}

--- a/src/main/java/com/example/petbuddybackend/service/chat/session/context/ContextCleanupCallback.java
+++ b/src/main/java/com/example/petbuddybackend/service/chat/session/context/ContextCleanupCallback.java
@@ -1,0 +1,6 @@
+package com.example.petbuddybackend.service.chat.session.context;
+
+@FunctionalInterface
+public interface ContextCleanupCallback {
+    void onDestroy(Long chatId, String username);
+}

--- a/src/main/java/com/example/petbuddybackend/service/mapper/ChatMapper.java
+++ b/src/main/java/com/example/petbuddybackend/service/mapper/ChatMapper.java
@@ -20,12 +20,10 @@ public interface ChatMapper {
     @Mapping(target = "senderEmail", source = "sender.email")
     @Mapping(target = "chatId", source = "chatRoom.id")
     @Mapping(target = "createdAt", source = "createdAt", qualifiedByName = "mapToZonedDateTime")
-    @Mapping(target = "seenByRecipient", expression = "java(chatMessage.isSeenByRecipient())")
     ChatMessageDTO mapToChatMessageDTO(ChatMessage chatMessage, @Context ZoneId zoneId);
 
     @Mapping(target = "senderEmail", source = "sender.email")
     @Mapping(target = "chatId", source = "chatRoom.id")
-    @Mapping(target = "seenByRecipient", expression = "java(chatMessage.isSeenByRecipient())")
     ChatMessageDTO mapToChatMessageDTO(ChatMessage chatMessage);
 
     @Mapping(target = "createdAt", source = "createdAt", qualifiedByName = "mapToZonedDateTime")

--- a/src/main/java/com/example/petbuddybackend/service/mapper/ChatMapper.java
+++ b/src/main/java/com/example/petbuddybackend/service/mapper/ChatMapper.java
@@ -20,10 +20,12 @@ public interface ChatMapper {
     @Mapping(target = "senderEmail", source = "sender.email")
     @Mapping(target = "chatId", source = "chatRoom.id")
     @Mapping(target = "createdAt", source = "createdAt", qualifiedByName = "mapToZonedDateTime")
+    @Mapping(target = "seenByRecipient", expression = "java(chatMessage.isSeenByRecipient())")
     ChatMessageDTO mapToChatMessageDTO(ChatMessage chatMessage, @Context ZoneId zoneId);
 
     @Mapping(target = "senderEmail", source = "sender.email")
     @Mapping(target = "chatId", source = "chatRoom.id")
+    @Mapping(target = "seenByRecipient", expression = "java(chatMessage.isSeenByRecipient())")
     ChatMessageDTO mapToChatMessageDTO(ChatMessage chatMessage);
 
     @Mapping(target = "createdAt", source = "createdAt", qualifiedByName = "mapToZonedDateTime")

--- a/src/main/java/com/example/petbuddybackend/utils/header/HeaderUtils.java
+++ b/src/main/java/com/example/petbuddybackend/utils/header/HeaderUtils.java
@@ -4,7 +4,9 @@ import com.example.petbuddybackend.utils.exception.throweable.websocket.InvalidW
 import com.example.petbuddybackend.utils.exception.throweable.websocket.MissingWebSocketHeaderException;
 import lombok.AccessLevel;
 import lombok.NoArgsConstructor;
+import org.springframework.messaging.simp.stomp.StompHeaderAccessor;
 
+import java.security.Principal;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -13,6 +15,10 @@ import java.util.Optional;
 public final class HeaderUtils {
 
     public static final String NATIVE_HEADERS = "nativeHeaders";
+    private static final String INVALID_TYPE_MESSAGE = "Header \"%s\" is not of type \"%s\"";
+    private static final String NO_VALUE_MESSAGE = "Header \"%s\" has no value";
+    private static final String MULTIPLE_VALUES_MESSAGE = "Header \"%s\" has multiple values";
+    private static final String HEADERS_ARE_NOT_OF_TYPE_MAP_MESSAGE = "Headers are not of type Map";
 
     /**
      * Extract first value of header from headers map
@@ -34,30 +40,75 @@ public final class HeaderUtils {
         return Optional.of(extractSingleHeaderValue(nativeHeaders, headerName, type));
     }
 
+    public static <T> T getHeaderSingleValue(StompHeaderAccessor accessor, String headerName, Class<T> type) {
+        return getOptionalHeaderSingleValue(accessor, headerName, type).orElseThrow(
+                () -> new MissingWebSocketHeaderException(headerName)
+        );
+    }
+
+    public static <T> Optional<T> getOptionalHeaderSingleValue(StompHeaderAccessor accessor, String headerName, Class<T> type) {
+        String value = accessor.getFirstNativeHeader(headerName);
+
+        if(value == null) {
+            return Optional.empty();
+        }
+
+        return Optional.of(castToType(headerName, value, type));
+    }
+
+    public static String getUser(StompHeaderAccessor accessor) {
+        Principal user = accessor.getUser();
+
+        if(user == null) {
+            throw new MissingWebSocketHeaderException("User");
+        }
+
+        return user.getName();
+    }
+
+    public static Long getLongFromDestination(StompHeaderAccessor accessor, int position) {
+        String destination = accessor.getDestination();
+
+        String[] parts = destination.split("/");
+        if (parts.length > position) {
+            return Long.parseLong(parts[position]);
+        }
+
+        throw new IndexOutOfBoundsException("Position pointing to out of bounds element");
+    }
+
+    @SuppressWarnings("unchecked")
     private static <T> T extractSingleHeaderValue(Map<String, Object> nativeHeaders, String headerName, Class<T> type) {
         Object header = nativeHeaders.get(headerName);
 
-        if(header instanceof List<?> headerList) {
-            if(headerList.isEmpty()) {
-                throw new InvalidWebSocketHeaderException("Header " + headerName + " has no value");
-            }
-
-            if(headerList.size() > 1) {
-                throw new InvalidWebSocketHeaderException("Header " + headerName + " has more than one value");
-            }
-
-            Object headerListObj = headerList.get(0);
-
-            if(type.isEnum()) {
-                return type.cast(Enum.valueOf((Class<Enum>) type, headerListObj.toString()));
-            }
-
-            if (type.isInstance(headerListObj)) {
-                return type.cast(headerListObj);
-            }
+        if(!(header instanceof List<?>)) {
+            throw new InvalidWebSocketHeaderException(String.format(INVALID_TYPE_MESSAGE, headerName, List.class.getSimpleName()));
         }
 
-        throw new InvalidWebSocketHeaderException("Header " + headerName + " is not of type " + type.getSimpleName());
+        List<Object> headerList = (List<Object>) header;
+
+        if(headerList.isEmpty()) {
+            throw new InvalidWebSocketHeaderException(String.format(NO_VALUE_MESSAGE, headerName));
+        }
+
+        if(headerList.size() > 1) {
+            throw new InvalidWebSocketHeaderException(MULTIPLE_VALUES_MESSAGE);
+        }
+
+        return castToType(headerName, headerList.get(0).toString(), type);
+    }
+
+    @SuppressWarnings("unchecked")
+    private static <T> T castToType(String headerName, String value, Class<T> type) {
+        if(type.isEnum()) {
+            return type.cast(Enum.valueOf((Class<Enum>) type, value));
+        }
+
+        if (type.isInstance(value)) {
+            return type.cast(value);
+        }
+
+        throw new InvalidWebSocketHeaderException(String.format(INVALID_TYPE_MESSAGE, headerName, type.getSimpleName()));
     }
 
     private static void checkHeaderExists(Map<String, Object> nativeHeaders, String headerName) {
@@ -74,6 +125,6 @@ public final class HeaderUtils {
             return (Map<String, Object>) nativeHeaders;
         }
 
-        throw new IllegalArgumentException("Headers are not of type Map");
+        throw new IllegalArgumentException(HEADERS_ARE_NOT_OF_TYPE_MAP_MESSAGE);
     }
 }

--- a/src/test/java/com/example/petbuddybackend/controller/ChatControllerTest.java
+++ b/src/test/java/com/example/petbuddybackend/controller/ChatControllerTest.java
@@ -104,7 +104,7 @@ public class ChatControllerTest {
     @Test
     @WithMockUser
     void getChatMessages_includeTimeZone_shouldSucceed() throws Exception {
-        when(chatService.getChatMessages(any(), any(), any(), any())).thenReturn(expectedMessagePage);
+        when(chatService.getChatMessagesByParticipantEmail(any(), any(), any(), any())).thenReturn(expectedMessagePage);
 
         mockMvc.perform(get("/api/chat/1/messages")
                         .param("page", "0")

--- a/src/test/java/com/example/petbuddybackend/controller/ChatWebSocketControllerTest.java
+++ b/src/test/java/com/example/petbuddybackend/controller/ChatWebSocketControllerTest.java
@@ -49,7 +49,7 @@ public class ChatWebSocketControllerTest {
 
     private static final String WEBSOCKET_URL_PATTERN = "ws://localhost:%s/ws";
     private static final String SEND_MESSAGE_ENDPOINT = "/app/chat/1";
-    private static final int TIMEOUT = 5;
+    private static final int TIMEOUT = 10;
 
     @Value("${url.chat.topic.pattern}")
     private String SUBSCRIPTION_URL_PATTERN;

--- a/src/test/java/com/example/petbuddybackend/controller/ChatWebSocketControllerTest.java
+++ b/src/test/java/com/example/petbuddybackend/controller/ChatWebSocketControllerTest.java
@@ -116,6 +116,9 @@ public class ChatWebSocketControllerTest {
         when(chatService.createMessage(any(), any(), any(), any()))
                 .thenReturn(returnPayload);
 
+        when(chatService.createCallbackMessageSeen(any(), any()))
+                .thenReturn(u -> {});
+
         when(chatService.isUserInChat(any(), any()))
                 .thenReturn(true);
 

--- a/src/test/java/com/example/petbuddybackend/controller/ChatWebSocketControllerTest.java
+++ b/src/test/java/com/example/petbuddybackend/controller/ChatWebSocketControllerTest.java
@@ -207,12 +207,14 @@ public class ChatWebSocketControllerTest {
         NoSecurityInjectUserConfig.injectedUsername = clientUsername;
         StompHeaders clientSubscribeHeaders = createHeaders(subscribeDestinationClient, "Europe/Warsaw");
         clientSession.subscribe(clientSubscribeHeaders, new ChatNotificationFrameHandler());
+        Thread.sleep(100);
 
         ChatNotificationJoined firstNotification = joinBlockingQueue.poll(2, SECONDS);
 
         NoSecurityInjectUserConfig.injectedUsername = caretakerUsername;
         StompHeaders caretakerSubscribeHeaders = createHeaders(subscribeDestinationCaretaker, "Europe/Warsaw");
         caretakerSession.subscribe(caretakerSubscribeHeaders, new ChatNotificationFrameHandler());
+        Thread.sleep(100);
 
         ChatNotificationJoined secondNotification = joinBlockingQueue.poll(2, SECONDS);
         ChatNotificationJoined thirdNotification = joinBlockingQueue.poll(2, SECONDS);

--- a/src/test/java/com/example/petbuddybackend/controller/ChatWebSocketControllerTest.java
+++ b/src/test/java/com/example/petbuddybackend/controller/ChatWebSocketControllerTest.java
@@ -49,6 +49,7 @@ public class ChatWebSocketControllerTest {
 
     private static final String WEBSOCKET_URL_PATTERN = "ws://localhost:%s/ws";
     private static final String SEND_MESSAGE_ENDPOINT = "/app/chat/1";
+    private static final int TIMEOUT = 5;
 
     @Value("${url.chat.topic.pattern}")
     private String SUBSCRIPTION_URL_PATTERN;
@@ -109,7 +110,7 @@ public class ChatWebSocketControllerTest {
         StompHeaders sendMessageHeaders = createHeaders(SEND_MESSAGE_ENDPOINT, "Europe/Warsaw", Role.CLIENT);
         stompSession.send(sendMessageHeaders, chatMessageSent);
 
-        ChatMessageDTO chatMessageDTO = (messageBlockingQueue.poll(2, SECONDS)).getContent();
+        ChatMessageDTO chatMessageDTO = (messageBlockingQueue.poll(TIMEOUT, SECONDS)).getContent();
         assertNotNull(chatMessageDTO);
     }
 
@@ -153,8 +154,8 @@ public class ChatWebSocketControllerTest {
         StompHeaders clientSendHeaders = createHeaders(SEND_MESSAGE_ENDPOINT, clientTimezone, Role.CLIENT);
         clientSession.send(clientSendHeaders, chatMessageSent);
 
-        ChatMessageDTO firstMessage = (messageBlockingQueue.poll(2, SECONDS)).getContent();
-        ChatMessageDTO secondMessage = (messageBlockingQueue.poll(2, SECONDS)).getContent();
+        ChatMessageDTO firstMessage = (messageBlockingQueue.poll(TIMEOUT, SECONDS)).getContent();
+        ChatMessageDTO secondMessage = (messageBlockingQueue.poll(TIMEOUT, SECONDS)).getContent();
 
         assertNotNull(firstMessage);
         assertNotNull(secondMessage);
@@ -209,15 +210,15 @@ public class ChatWebSocketControllerTest {
         clientSession.subscribe(clientSubscribeHeaders, new ChatNotificationFrameHandler());
         Thread.sleep(100);
 
-        ChatNotificationJoined firstNotification = joinBlockingQueue.poll(2, SECONDS);
+        ChatNotificationJoined firstNotification = joinBlockingQueue.poll(TIMEOUT, SECONDS);
 
         NoSecurityInjectUserConfig.injectedUsername = caretakerUsername;
         StompHeaders caretakerSubscribeHeaders = createHeaders(subscribeDestinationCaretaker, "Europe/Warsaw");
         caretakerSession.subscribe(caretakerSubscribeHeaders, new ChatNotificationFrameHandler());
         Thread.sleep(100);
 
-        ChatNotificationJoined secondNotification = joinBlockingQueue.poll(2, SECONDS);
-        ChatNotificationJoined thirdNotification = joinBlockingQueue.poll(2, SECONDS);
+        ChatNotificationJoined secondNotification = joinBlockingQueue.poll(TIMEOUT, SECONDS);
+        ChatNotificationJoined thirdNotification = joinBlockingQueue.poll(TIMEOUT, SECONDS);
 
         assertNotNull(firstNotification);
         assertEquals(clientUsername, firstNotification.getJoiningUserEmail());
@@ -256,7 +257,7 @@ public class ChatWebSocketControllerTest {
 
         clientSession.disconnect();
         Thread.sleep(200);
-        ChatNotificationLeft clientLeftNotification = leaveBlockingQueue.poll(2, SECONDS);
+        ChatNotificationLeft clientLeftNotification = leaveBlockingQueue.poll(TIMEOUT, SECONDS);
 
         assertNotNull(clientLeftNotification);
         assertEquals(clientUsername, clientLeftNotification.getLeavingUserEmail());

--- a/src/test/java/com/example/petbuddybackend/service/chat/ChatServiceTest.java
+++ b/src/test/java/com/example/petbuddybackend/service/chat/ChatServiceTest.java
@@ -314,11 +314,11 @@ public class ChatServiceTest {
         long chatsCount = chatRepository.count();
 
         ChatMessageDTO msg = chatService.createChatRoomWithMessage(
-            otherCaretaker.getEmail(),
-            otherClientWithCaretakerAccount.getEmail(),
-            Role.CLIENT,
-            new ChatMessageSent("message content"),
-            ZoneId.of("Europe/Warsaw")
+                otherCaretaker.getEmail(),
+                Role.CLIENT,
+                otherClientWithCaretakerAccount.getEmail(),
+                new ChatMessageSent("message content"),
+                ZoneId.of("Europe/Warsaw")
         );
 
         assertEquals("message content", msg.getContent());
@@ -332,8 +332,8 @@ public class ChatServiceTest {
 
         ChatMessageDTO msg = chatService.createChatRoomWithMessage(
                 otherClientWithCaretakerAccount.getEmail(),
-                otherCaretaker.getEmail(),
                 Role.CARETAKER,
+                otherCaretaker.getEmail(),
                 new ChatMessageSent("message content"),
                 ZoneId.of("Europe/Warsaw")
         );
@@ -348,8 +348,8 @@ public class ChatServiceTest {
     void testCreateChatRoomWithMessage_timeZoneProvided_shouldSucceed(String timeZone) {
         ChatMessageDTO msg = chatService.createChatRoomWithMessage(
                 otherCaretaker.getEmail(),
-                otherClientWithCaretakerAccount.getEmail(),
                 Role.CLIENT,
+                otherClientWithCaretakerAccount.getEmail(),
                 new ChatMessageSent("message content"),
                 ZoneId.of(timeZone)
         );
@@ -363,8 +363,8 @@ public class ChatServiceTest {
                 InvalidMessageReceiverException.class,
                 () -> chatService.createChatRoomWithMessage(
                         otherClientWithCaretakerAccount.getEmail(),
-                        otherClientWithCaretakerAccount.getEmail(),
                         Role.CARETAKER,
+                        otherClientWithCaretakerAccount.getEmail(),
                         new ChatMessageSent("message content"),
                         ZoneId.of("Europe/Warsaw")
                 )
@@ -377,8 +377,8 @@ public class ChatServiceTest {
                 ChatAlreadyExistsException.class,
                 () -> chatService.createChatRoomWithMessage(
                         caretaker.getEmail(),
-                        client.getEmail(),
                         Role.CLIENT,
+                        client.getEmail(),
                         new ChatMessageSent("message content"),
                         ZoneId.of("Europe/Warsaw")
                 )
@@ -388,8 +388,8 @@ public class ChatServiceTest {
                 ChatAlreadyExistsException.class,
                 () -> chatService.createChatRoomWithMessage(
                         client.getEmail(),
-                        caretaker.getEmail(),
                         Role.CARETAKER,
+                        caretaker.getEmail(),
                         new ChatMessageSent("message content"),
                         ZoneId.of("Europe/Warsaw")
                 )

--- a/src/test/java/com/example/petbuddybackend/service/chat/ChatServiceTest.java
+++ b/src/test/java/com/example/petbuddybackend/service/chat/ChatServiceTest.java
@@ -115,13 +115,13 @@ public class ChatServiceTest {
     void testGetChatMessages_shouldSucceed() {
         Pageable pageable = PageRequest.of(0, 10);
 
-        Page<ChatMessageDTO> clientChatMessages = chatService.getChatMessages(
+        Page<ChatMessageDTO> clientChatMessages = chatService.getChatMessagesByParticipantEmail(
                 chatRoom.getId(),
                 client.getEmail(),
                 pageable,
                 ZoneId.of("Europe/Warsaw")
         );
-        Page<ChatMessageDTO> caretakerChatMessages = chatService.getChatMessages(
+        Page<ChatMessageDTO> caretakerChatMessages = chatService.getChatMessagesByParticipantEmail(
                 chatRoom.getId(),
                 caretaker.getEmail(),
                 pageable,
@@ -138,7 +138,7 @@ public class ChatServiceTest {
         Pageable pageable = PageRequest.of(0, 10);
         ZoneId zoneId = ZoneId.of(timeZone);
 
-        Page<ChatMessageDTO> clientChatMessages = chatService.getChatMessages(chatRoom.getId(), client.getEmail(), pageable, zoneId);
+        Page<ChatMessageDTO> clientChatMessages = chatService.getChatMessagesByParticipantEmail(chatRoom.getId(), client.getEmail(), pageable, zoneId);
 
         for(ChatMessageDTO chatMessageDTO : clientChatMessages.getContent()) {
             assertEquals(zoneId, chatMessageDTO.getCreatedAt().getZone());
@@ -149,7 +149,7 @@ public class ChatServiceTest {
     void testGetChatMessages_chatDoesNotExist_shouldThrowNotFoundException() {
         assertThrows(
                 NotFoundException.class,
-                () -> chatService.getChatMessages(-1L, "", null, ZoneId.of("Europe/Warsaw"))
+                () -> chatService.getChatMessagesByParticipantEmail(-1L, "", null, ZoneId.of("Europe/Warsaw"))
         );
     }
 
@@ -157,7 +157,7 @@ public class ChatServiceTest {
     void testGetChatMessages_userDoesNotParticipateChat_shouldThrowNotParticipateException() {
         assertThrows(
                 NotParticipateException.class,
-                () -> chatService.getChatMessages(chatRoom.getId(), "notAParticipant", null, ZoneId.of("Europe/Warsaw"))
+                () -> chatService.getChatMessagesByParticipantEmail(chatRoom.getId(), "notAParticipant", null, ZoneId.of("Europe/Warsaw"))
         );
     }
 

--- a/src/test/java/com/example/petbuddybackend/service/chat/ChatServiceTest.java
+++ b/src/test/java/com/example/petbuddybackend/service/chat/ChatServiceTest.java
@@ -314,9 +314,9 @@ public class ChatServiceTest {
         long chatsCount = chatRepository.count();
 
         ChatMessageDTO msg = chatService.createChatRoomWithMessage(
-                otherCaretaker.getEmail(),
-                Role.CLIENT,
                 otherClientWithCaretakerAccount.getEmail(),
+                Role.CLIENT,
+                otherCaretaker.getEmail(),
                 new ChatMessageSent("message content"),
                 ZoneId.of("Europe/Warsaw")
         );
@@ -331,9 +331,9 @@ public class ChatServiceTest {
         long chatsCount = chatRepository.count();
 
         ChatMessageDTO msg = chatService.createChatRoomWithMessage(
-                otherClientWithCaretakerAccount.getEmail(),
-                Role.CARETAKER,
                 otherCaretaker.getEmail(),
+                Role.CARETAKER,
+                otherClientWithCaretakerAccount.getEmail(),
                 new ChatMessageSent("message content"),
                 ZoneId.of("Europe/Warsaw")
         );
@@ -347,9 +347,9 @@ public class ChatServiceTest {
     @MethodSource("provideTimeZones")
     void testCreateChatRoomWithMessage_timeZoneProvided_shouldSucceed(String timeZone) {
         ChatMessageDTO msg = chatService.createChatRoomWithMessage(
-                otherCaretaker.getEmail(),
-                Role.CLIENT,
                 otherClientWithCaretakerAccount.getEmail(),
+                Role.CLIENT,
+                otherCaretaker.getEmail(),
                 new ChatMessageSent("message content"),
                 ZoneId.of(timeZone)
         );
@@ -376,9 +376,9 @@ public class ChatServiceTest {
         assertThrows(
                 ChatAlreadyExistsException.class,
                 () -> chatService.createChatRoomWithMessage(
-                        caretaker.getEmail(),
-                        Role.CLIENT,
                         client.getEmail(),
+                        Role.CLIENT,
+                        caretaker.getEmail(),
                         new ChatMessageSent("message content"),
                         ZoneId.of("Europe/Warsaw")
                 )
@@ -387,9 +387,9 @@ public class ChatServiceTest {
         assertThrows(
                 ChatAlreadyExistsException.class,
                 () -> chatService.createChatRoomWithMessage(
-                        client.getEmail(),
-                        Role.CARETAKER,
                         caretaker.getEmail(),
+                        Role.CARETAKER,
+                        client.getEmail(),
                         new ChatMessageSent("message content"),
                         ZoneId.of("Europe/Warsaw")
                 )

--- a/src/test/java/com/example/petbuddybackend/service/chat/session/ChatSessionServiceTest.java
+++ b/src/test/java/com/example/petbuddybackend/service/chat/session/ChatSessionServiceTest.java
@@ -6,7 +6,6 @@ import com.example.petbuddybackend.service.mapper.ChatMapper;
 import com.example.petbuddybackend.testutils.mock.MockChatProvider;
 import com.example.petbuddybackend.utils.header.HeaderUtils;
 import org.junit.jupiter.api.Test;
-import org.mockito.Mock;
 import org.mockito.MockedStatic;
 import org.mockito.Mockito;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -14,7 +13,6 @@ import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.messaging.simp.SimpMessagingTemplate;
-import org.springframework.messaging.simp.stomp.StompHeaderAccessor;
 
 import java.time.ZoneId;
 import java.util.Map;
@@ -29,9 +27,6 @@ public class ChatSessionServiceTest {
     @Value("${url.chat.topic.pattern}")
     private String SUBSCRIPTION_URL_PATTERN;
 
-    @Value("${header-name.timezone}")
-    private String TIMEZONE_HEADER_NAME;
-
     @Autowired
     private ChatSessionService chatSessionService;
 
@@ -40,9 +35,6 @@ public class ChatSessionServiceTest {
 
     @MockBean
     private ChatSessionManager chatSessionManager;
-
-    @Mock
-    private StompHeaderAccessor accessor;
 
     private ChatMapper chatMapper = ChatMapper.INSTANCE;
 
@@ -81,10 +73,8 @@ public class ChatSessionServiceTest {
             headerUtilsMockedStatic.when(() -> HeaderUtils.getOptionalHeaderSingleValue(any(Map.class), any(), any()))
                     .thenReturn(Optional.of(newTimeZone));
 
-            // when
             chatSessionService.patchMetadata(chatId, username, headers);
 
-            // then
             verify(chatSessionManager).get(chatId, username);
             assertEquals(newZoneId, existingMetadata.getZoneId());
         }
@@ -92,16 +82,13 @@ public class ChatSessionServiceTest {
 
     @Test
     void testSubscribeIfAbsent_shouldCreateUserMetadata() {
-        // Arrange
         Long chatId = 1L;
         String username = "testUser";
         String timeZone = "America/New_York";
         ZoneId expectedZoneId = ZoneId.of(timeZone);
 
-        // Act
         chatSessionService.subscribeIfAbsent(chatId, username, timeZone);
 
-        // Assert
         verify(chatSessionManager).putIfAbsent(
                 eq(chatId),
                 argThat(meta -> username.equals(meta.getUsername()) && expectedZoneId.equals(meta.getZoneId()))
@@ -110,50 +97,25 @@ public class ChatSessionServiceTest {
 
     @Test
     void testSubscribeIfAbsent_shouldSubscribeUser() {
-        // Arrange
         String username = "testUser";
         String timeZone = "America/New_York";
         Long chatId = 1L;
 
-        // Act
         chatSessionService.subscribeIfAbsent(chatId, username, timeZone);
 
-        // Assert
-        verify(chatSessionManager, times(1)).putIfAbsent(
-                eq(chatId),
-                any()
-        );
-        verify(accessor).getUser();
-        verify(accessor).getDestination();
-        verify(accessor).getFirstNativeHeader(TIMEZONE_HEADER_NAME);
+        verify(chatSessionManager, times(1))
+                .putIfAbsent(eq(chatId), any());
     }
 
     @Test
     void testUnsubscribeIfPresent_shouldRemoveUserFromChatSession() {
-        // given
         Long chatId = 1L;
         String username = "testUser";
 
-        // when
         chatSessionService.unsubscribeIfPresent(chatId, username);
 
-        // then
-        verify(chatSessionManager).remove(chatId, username);
-    }
-
-    @Test
-    void testUnsubscribeIfPresent_withStompHeaderAccessor_shouldRemoveUserFromChatSession() {
-        // given
-        String username = "testUser";
-        Long chatId = 1L;
-
-        // when
-        chatSessionService.unsubscribeIfPresent(chatId, username);
-
-        // then
-        verify(accessor).getUser();
-        verify(accessor).getDestination();
-        verify(chatSessionManager).remove(chatId, username);
+        verify(chatSessionManager)
+                .remove(chatId, username);
     }
 
     private ChatRoomMetadata createChatUserMeta(String firstUsername, String secondUsername) {

--- a/src/test/java/com/example/petbuddybackend/service/chat/session/ChatSessionServiceTest.java
+++ b/src/test/java/com/example/petbuddybackend/service/chat/session/ChatSessionServiceTest.java
@@ -148,17 +148,6 @@ public class ChatSessionServiceTest {
                 .putIfAbsent(eq(chatId), any());
     }
 
-//    @Test
-//    void testUnsubscribeIfPresent_shouldRemoveUserFromChatSession() {
-//        Long chatId = 1L;
-//        String username = "testUser";
-//
-//        chatSessionService.unsubscribeIfPresent(chatId, username);
-//
-//        verify(chatSessionManager)
-//                .remove(chatId, username);
-//    }
-
     private ChatRoomMetadata createChatUserMeta(String firstUsername, String secondUsername) {
         return new ChatRoomMetadata(
                 new ChatUserMetadata(firstUsername, ZoneId.systemDefault()),

--- a/src/test/java/com/example/petbuddybackend/service/chat/session/ChatSessionServiceTest.java
+++ b/src/test/java/com/example/petbuddybackend/service/chat/session/ChatSessionServiceTest.java
@@ -1,6 +1,7 @@
 package com.example.petbuddybackend.service.chat.session;
 
 import com.example.petbuddybackend.dto.chat.ChatMessageDTO;
+import com.example.petbuddybackend.dto.chat.notification.ChatNotificationMessage;
 import com.example.petbuddybackend.service.mapper.ChatMapper;
 import com.example.petbuddybackend.testutils.mock.MockChatProvider;
 import com.example.petbuddybackend.utils.header.HeaderUtils;
@@ -52,7 +53,7 @@ public class ChatSessionServiceTest {
         ChatRoomMetadata chatRoomMetadata = createChatUserMeta("fstUsername", "sndUsername");
         when(chatSessionManager.get(chatId)).thenReturn(chatRoomMetadata);
 
-        chatSessionService.sendMessages(chatId, messageDTO, (empty) -> {});
+        chatSessionService.sendNotifications(chatId, new ChatNotificationMessage(messageDTO), (empty) -> {});
 
         for (ChatUserMetadata userMetadata : chatRoomMetadata) {
             verify(simpMessagingTemplate, times(1)).convertAndSend(

--- a/src/test/java/com/example/petbuddybackend/service/chat/session/context/ChatSessionContextTest.java
+++ b/src/test/java/com/example/petbuddybackend/service/chat/session/context/ChatSessionContextTest.java
@@ -1,0 +1,55 @@
+package com.example.petbuddybackend.service.chat.session.context;
+
+import com.example.petbuddybackend.testutils.ValidationUtils;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+
+import java.util.Set;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.verify;
+
+public class ChatSessionContextTest {
+
+    private ChatSessionContext chatSessionContext;
+    private ContextCleanupCallback cleanupCallback;
+
+    @BeforeEach
+    void setUp() {
+        cleanupCallback = Mockito.mock(ContextCleanupCallback.class);
+        chatSessionContext = new ChatSessionContext(1L, "testUser", cleanupCallback);
+    }
+
+    @Test
+    void testSetContext_shouldSetParams() {
+        chatSessionContext.setContext(2L, "newUser", cleanupCallback);
+        assertEquals(2L, chatSessionContext.getChatId());
+        assertEquals("newUser", chatSessionContext.getUsername());
+        assertFalse(chatSessionContext.isEmpty());
+    }
+
+    @Test
+    void testClearContext_allParamsShouldBeNull() {
+        chatSessionContext.clearContext();
+        assertFalse(ValidationUtils.fieldsNotNullRecursive(chatSessionContext, Set.of("cleanupCallback")));
+    }
+
+    @Test
+    void testDestroy_shouldCallOnDestroy() {
+        chatSessionContext.destroy();
+        verify(cleanupCallback).onDestroy(1L, "testUser");
+    }
+
+    @Test
+    void testIsEmpty_afterClearContext_shouldReturnTrue() {
+        chatSessionContext.clearContext();
+        assertTrue(chatSessionContext.isEmpty());
+    }
+
+    @Test
+    void testIsEmpty_contextWasSet_shouldReturnFalse() {
+        chatSessionContext.setContext(3L, "testUser2", cleanupCallback);
+        assertFalse(chatSessionContext.isEmpty());
+    }
+}

--- a/src/test/java/com/example/petbuddybackend/service/mapper/ChatMapperTest.java
+++ b/src/test/java/com/example/petbuddybackend/service/mapper/ChatMapperTest.java
@@ -33,6 +33,7 @@ public class ChatMapperTest {
         ChatRoom chatRoom = MockChatProvider.createMockChatRoom(client, caretaker);
         chatRoom.setId(1L);
         chatMessage.setId(2L);
+        chatMessage.setSeenByRecipient(true);
         chatMessage.setChatRoom(chatRoom);
         chatMessage.setCreatedAt(ZonedDateTime.now().withZoneSameInstant(tokyoZone));
     }

--- a/src/test/java/com/example/petbuddybackend/testutils/mock/GeneralMockProvider.java
+++ b/src/test/java/com/example/petbuddybackend/testutils/mock/GeneralMockProvider.java
@@ -2,9 +2,12 @@ package com.example.petbuddybackend.testutils.mock;
 
 import com.example.petbuddybackend.utils.header.HeaderUtils;
 import lombok.NoArgsConstructor;
+import org.springframework.messaging.simp.stomp.StompCommand;
+import org.springframework.messaging.simp.stomp.StompHeaderAccessor;
 import org.springframework.security.oauth2.jwt.Jwt;
 import org.springframework.security.oauth2.server.resource.authentication.JwtAuthenticationToken;
 
+import java.security.Principal;
 import java.util.*;
 
 import static org.mockito.Mockito.mock;
@@ -54,5 +57,41 @@ public final class GeneralMockProvider {
         headers.put(HeaderUtils.NATIVE_HEADERS, nativeHeaders);
 
         return headers;
+    }
+
+    public static StompHeaderAccessor createStompHeaderAccessorWithSingleValue(String testHeader, String testValue) {
+        StompHeaderAccessor accessor = StompHeaderAccessor.create(StompCommand.CONNECT);
+        accessor.setNativeHeader(testHeader, testValue);
+        accessor.setLeaveMutable(false);
+
+        return accessor;
+    }
+
+    public static StompHeaderAccessor createStompHeaderAccessorWithUser(String testUser) {
+        StompHeaderAccessor accessor = StompHeaderAccessor.create(StompCommand.CONNECT);
+        Principal principal = () -> testUser;
+
+        accessor.setUser(principal);
+        accessor.setLeaveMutable(false);
+
+        return accessor;
+    }
+
+    public static StompHeaderAccessor createStompHeaderAccessorWithoutUser() {
+        StompHeaderAccessor accessor = StompHeaderAccessor.create(StompCommand.CONNECT);
+
+        accessor.setUser(null);
+        accessor.setLeaveMutable(false);
+
+        return accessor;
+    }
+
+    public static StompHeaderAccessor createStompHeaderAccessorWithDestination(String path) {
+        StompHeaderAccessor accessor = StompHeaderAccessor.create(StompCommand.SEND);
+
+        accessor.setDestination(path);
+        accessor.setLeaveMutable(false);
+
+        return accessor;
     }
 }

--- a/src/test/java/com/example/petbuddybackend/testutils/mock/MockChatProvider.java
+++ b/src/test/java/com/example/petbuddybackend/testutils/mock/MockChatProvider.java
@@ -25,16 +25,21 @@ public final class MockChatProvider {
         return List.of(clientMessage, caretakerMessage);
     }
 
-    public static ChatMessage createMockChatMessage(AppUser sender) {
-        return createMockChatMessage(sender, ZonedDateTime.now());
-    }
-
-    public static ChatMessage createMockChatMessage(AppUser sender, ZonedDateTime createdAt) {
+    public static ChatMessage createMockChatMessage(AppUser sender, ZonedDateTime createdAt, ChatRoom chatRoom) {
         return ChatMessage.builder()
                 .content(UUID.randomUUID().toString())
                 .createdAt(createdAt)
+                .chatRoom(chatRoom)
                 .sender(sender)
                 .build();
+    }
+
+    public static ChatMessage createMockChatMessage(AppUser sender, ZonedDateTime createdAt) {
+        return createMockChatMessage(sender, createdAt, null);
+    }
+
+    public static ChatMessage createMockChatMessage(AppUser sender) {
+        return createMockChatMessage(sender, ZonedDateTime.now());
     }
 
     public static ChatRoom createMockChatRoom(Client client, Caretaker caretaker) {

--- a/src/test/java/com/example/petbuddybackend/utils/HeaderUtilsTest.java
+++ b/src/test/java/com/example/petbuddybackend/utils/HeaderUtilsTest.java
@@ -6,6 +6,7 @@ import com.example.petbuddybackend.utils.exception.throweable.websocket.InvalidW
 import com.example.petbuddybackend.utils.exception.throweable.websocket.MissingWebSocketHeaderException;
 import com.example.petbuddybackend.utils.header.HeaderUtils;
 import org.junit.jupiter.api.Test;
+import org.springframework.messaging.simp.stomp.StompHeaderAccessor;
 
 import java.util.*;
 
@@ -85,5 +86,45 @@ public class HeaderUtilsTest {
         Map<String, Object> headers = GeneralMockProvider.createHeadersWithSingleValue("Accept-Role", "CLIENT");
         Role role = HeaderUtils.getHeaderSingleValue(headers, "Accept-Role", Role.class);
         assertNotNull(role);
+    }
+
+    @Test
+    void testGetHeaderSingleValue_withStompAccessor_validHeader_shouldSucceed() {
+        StompHeaderAccessor accessor = GeneralMockProvider.createStompHeaderAccessorWithSingleValue("testHeader", "testValue");
+        String result = HeaderUtils.getHeaderSingleValue(accessor, "testHeader", String.class);
+        assertEquals("testValue", result);
+    }
+
+    @Test
+    void testGetHeaderSingleValue_withStompAccessor_missingHeader_shouldThrowMissingWebSocketHeaderException() {
+        StompHeaderAccessor accessor = GeneralMockProvider.createStompHeaderAccessorWithSingleValue("anotherHeader", "testValue");
+        assertThrows(MissingWebSocketHeaderException.class, () ->
+                HeaderUtils.getHeaderSingleValue(accessor, "testHeader", String.class));
+    }
+
+    @Test
+    void testGetUser_withStompAccessor_userPresent_shouldReturnUserName() {
+        StompHeaderAccessor accessor = GeneralMockProvider.createStompHeaderAccessorWithUser("testUser");
+        String userName = HeaderUtils.getUser(accessor);
+        assertEquals("testUser", userName);
+    }
+
+    @Test
+    void testGetUser_withStompAccessor_noUser_shouldThrowMissingWebSocketHeaderException() {
+        StompHeaderAccessor accessor = GeneralMockProvider.createStompHeaderAccessorWithoutUser();
+        assertThrows(MissingWebSocketHeaderException.class, () -> HeaderUtils.getUser(accessor));
+    }
+
+    @Test
+    void testGetLongFromDestination_validDestination_shouldReturnParsedLong() {
+        StompHeaderAccessor accessor = GeneralMockProvider.createStompHeaderAccessorWithDestination("/topic/12345");
+        Long result = HeaderUtils.getLongFromDestination(accessor, 2);
+        assertEquals(12345L, result);
+    }
+
+    @Test
+    void testGetLongFromDestination_invalidPosition_shouldThrowIndexOutOfBoundsException() {
+        StompHeaderAccessor accessor = GeneralMockProvider.createStompHeaderAccessorWithDestination("/topic/12345");
+        assertThrows(IndexOutOfBoundsException.class, () -> HeaderUtils.getLongFromDestination(accessor, 3));
     }
 }


### PR DESCRIPTION
1) Dodanie atrybutu 'seenByRecipient', czyli informacji o tym, czy odbiorca wiadomości odczytał wiadomość:
- Do ChatMessageDTO
- W ChatRoomDTO jest za to seenByPrincipal, co można interpretować jako 'przeczytane przez ciebie (osobę wysyłającą zapytanie)
- Wysyłanie wiadomości w websocketach o dołączeniu użytkownika do chatu oraz jego rozłączenia

2) Bugfixy:
- Dodano poprzez `DisposeableBean` usuwanie danych w sesji użytkownika w przypadku jego rozłączenia z sesją bez jawnego anulowania subskrypcji