### PR TITLE
Gawron/ZPI-39-ZPI-79-BE-49-Wydzielenie-DTO-dla-ofert

### DIFF
--- a/src/main/java/com/example/petbuddybackend/controller/CaretakerController.java
+++ b/src/main/java/com/example/petbuddybackend/controller/CaretakerController.java
@@ -5,6 +5,7 @@ import com.example.petbuddybackend.dto.offer.OfferFilterDTO;
 import com.example.petbuddybackend.dto.paging.SortedPagingParams;
 import com.example.petbuddybackend.dto.rating.RatingRequest;
 import com.example.petbuddybackend.dto.rating.RatingResponse;
+import com.example.petbuddybackend.dto.user.CaretakerComplexInfoDTO;
 import com.example.petbuddybackend.dto.user.CaretakerDTO;
 import com.example.petbuddybackend.dto.user.CreateCaretakerDTO;
 import com.example.petbuddybackend.dto.user.UpdateCaretakerDTO;
@@ -56,7 +57,7 @@ public class CaretakerController {
             description = "Add caretaker profile if it does not exists"
     )
     @PreAuthorize("isAuthenticated()")
-    public CaretakerDTO addCaretaker(
+    public CaretakerComplexInfoDTO addCaretaker(
             @RequestBody @Valid CreateCaretakerDTO caretakerDTO,
             Principal principal
     ) {
@@ -69,7 +70,7 @@ public class CaretakerController {
             description = "Edit caretaker profile if it does exists"
     )
     @PreAuthorize("isAuthenticated()")
-    public CaretakerDTO editCaretaker(
+    public CaretakerComplexInfoDTO editCaretaker(
             @RequestBody @Valid UpdateCaretakerDTO caretakerDTO,
             Principal principal
     ) {

--- a/src/main/java/com/example/petbuddybackend/controller/OfferController.java
+++ b/src/main/java/com/example/petbuddybackend/controller/OfferController.java
@@ -1,6 +1,8 @@
 package com.example.petbuddybackend.controller;
 
 import com.example.petbuddybackend.dto.availability.CreateOffersAvailabilityDTO;
+import com.example.petbuddybackend.dto.offer.ModifyConfigurationDTO;
+import com.example.petbuddybackend.dto.offer.ModifyOfferDTO;
 import com.example.petbuddybackend.dto.offer.OfferConfigurationDTO;
 import com.example.petbuddybackend.dto.offer.OfferDTO;
 import com.example.petbuddybackend.service.offer.OfferService;
@@ -30,7 +32,7 @@ public class OfferController {
     )
     @PostMapping("/add-or-edit")
     @PreAuthorize("isAuthenticated()")
-    public OfferDTO addOrEditOffer(@RequestBody OfferDTO offer, Principal principal) {
+    public OfferDTO addOrEditOffer(@RequestBody ModifyOfferDTO offer, Principal principal) {
         return offerService.addOrEditOffer(offer, principal.getName());
     }
 
@@ -44,7 +46,7 @@ public class OfferController {
     @PostMapping("/configuration/{configurationId}/edit")
     @PreAuthorize("isAuthenticated()")
     public OfferConfigurationDTO editConfiguration(@PathVariable Long configurationId,
-                                                                   @RequestBody OfferConfigurationDTO configuration) {
+                                                                   @RequestBody ModifyConfigurationDTO configuration) {
         return offerService.editConfiguration(configurationId, configuration);
     }
 

--- a/src/main/java/com/example/petbuddybackend/controller/OfferController.java
+++ b/src/main/java/com/example/petbuddybackend/controller/OfferController.java
@@ -32,7 +32,7 @@ public class OfferController {
     )
     @PostMapping("/add-or-edit")
     @PreAuthorize("isAuthenticated()")
-    public OfferDTO addOrEditOffer(@RequestBody ModifyOfferDTO offer, Principal principal) {
+    public OfferDTO addOrEditOffer(@RequestBody @Valid ModifyOfferDTO offer, Principal principal) {
         return offerService.addOrEditOffer(offer, principal.getName());
     }
 
@@ -46,7 +46,7 @@ public class OfferController {
     @PostMapping("/configuration/{configurationId}/edit")
     @PreAuthorize("isAuthenticated()")
     public OfferConfigurationDTO editConfiguration(@PathVariable Long configurationId,
-                                                                   @RequestBody ModifyConfigurationDTO configuration) {
+                                                   @RequestBody @Valid ModifyConfigurationDTO configuration) {
         return offerService.editConfiguration(configurationId, configuration);
     }
 

--- a/src/main/java/com/example/petbuddybackend/dto/animal/AnimalDTO.java
+++ b/src/main/java/com/example/petbuddybackend/dto/animal/AnimalDTO.java
@@ -1,9 +1,11 @@
 package com.example.petbuddybackend.dto.animal;
 
+import jakarta.validation.constraints.NotBlank;
 import lombok.Builder;
 
 @Builder
 public record AnimalDTO(
+        @NotBlank
         String animalType
 ) {
 }

--- a/src/main/java/com/example/petbuddybackend/dto/offer/ModifyConfigurationDTO.java
+++ b/src/main/java/com/example/petbuddybackend/dto/offer/ModifyConfigurationDTO.java
@@ -1,5 +1,9 @@
 package com.example.petbuddybackend.dto.offer;
 
+import jakarta.validation.constraints.DecimalMin;
+import jakarta.validation.constraints.Digits;
+import jakarta.validation.constraints.NotEmpty;
+import jakarta.validation.constraints.NotNull;
 import lombok.Builder;
 
 import java.math.BigDecimal;
@@ -9,7 +13,14 @@ import java.util.Map;
 @Builder
 public record ModifyConfigurationDTO(
         String description,
+
+        @NotNull
+        @DecimalMin(value = "0.0", inclusive = false)
+        @Digits(integer = 5, fraction = 2)
         BigDecimal dailyPrice,
-        Map<String, List<String>> selectedOptions
+
+        @NotNull
+        @NotEmpty
+        Map<String, @NotEmpty List<String>> selectedOptions
 ) {
 }

--- a/src/main/java/com/example/petbuddybackend/dto/offer/ModifyConfigurationDTO.java
+++ b/src/main/java/com/example/petbuddybackend/dto/offer/ModifyConfigurationDTO.java
@@ -1,0 +1,15 @@
+package com.example.petbuddybackend.dto.offer;
+
+import lombok.Builder;
+
+import java.math.BigDecimal;
+import java.util.List;
+import java.util.Map;
+
+@Builder
+public record ModifyConfigurationDTO(
+        String description,
+        BigDecimal dailyPrice,
+        Map<String, List<String>> selectedOptions
+) {
+}

--- a/src/main/java/com/example/petbuddybackend/dto/offer/ModifyOfferDTO.java
+++ b/src/main/java/com/example/petbuddybackend/dto/offer/ModifyOfferDTO.java
@@ -1,6 +1,8 @@
 package com.example.petbuddybackend.dto.offer;
 
 import com.example.petbuddybackend.dto.animal.AnimalDTO;
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.NotNull;
 import lombok.Builder;
 
 import java.util.List;
@@ -8,8 +10,11 @@ import java.util.List;
 @Builder
 public record ModifyOfferDTO(
         String description,
+
+        @NotNull
+        @Valid
         AnimalDTO animal,
-        List<ModifyConfigurationDTO> offerConfigurations,
+        List<@Valid ModifyConfigurationDTO> offerConfigurations,
         List<String> animalAmenities
 ) {
 }

--- a/src/main/java/com/example/petbuddybackend/dto/offer/ModifyOfferDTO.java
+++ b/src/main/java/com/example/petbuddybackend/dto/offer/ModifyOfferDTO.java
@@ -1,0 +1,15 @@
+package com.example.petbuddybackend.dto.offer;
+
+import com.example.petbuddybackend.dto.animal.AnimalDTO;
+import lombok.Builder;
+
+import java.util.List;
+
+@Builder
+public record ModifyOfferDTO(
+        String description,
+        AnimalDTO animal,
+        List<ModifyConfigurationDTO> offerConfigurations,
+        List<String> animalAmenities
+) {
+}

--- a/src/main/java/com/example/petbuddybackend/dto/user/CaretakerComplexInfoDTO.java
+++ b/src/main/java/com/example/petbuddybackend/dto/user/CaretakerComplexInfoDTO.java
@@ -1,0 +1,18 @@
+package com.example.petbuddybackend.dto.user;
+
+import com.example.petbuddybackend.dto.address.AddressDTO;
+import com.example.petbuddybackend.dto.offer.OfferDTO;
+import lombok.Builder;
+import java.util.List;
+
+@Builder
+public record CaretakerComplexInfoDTO(
+    AccountDataDTO accountData,
+    String phoneNumber,
+    String description,
+    AddressDTO address,
+    List<String> animals,
+    List<OfferDTO> offers,
+    Integer numberOfRatings,
+    Float avgRating
+){}

--- a/src/main/java/com/example/petbuddybackend/dto/user/CaretakerDTO.java
+++ b/src/main/java/com/example/petbuddybackend/dto/user/CaretakerDTO.java
@@ -1,18 +1,16 @@
 package com.example.petbuddybackend.dto.user;
 
 import com.example.petbuddybackend.dto.address.AddressDTO;
-import com.example.petbuddybackend.dto.offer.OfferDTO;
 import lombok.Builder;
+
 import java.util.List;
 
 @Builder
-public record CaretakerDTO (
-    AccountDataDTO accountData,
-    String phoneNumber,
-    String description,
-    AddressDTO address,
-    List<String> animals,
-    List<OfferDTO> offers,
-    Integer numberOfRatings,
-    Float avgRating
-){}
+public record CaretakerDTO(
+        AccountDataDTO accountData,
+        AddressDTO address,
+        List<String> animals,
+        Integer numberOfRatings,
+        Float avgRating
+) {
+}

--- a/src/main/java/com/example/petbuddybackend/service/mapper/AddressMapper.java
+++ b/src/main/java/com/example/petbuddybackend/service/mapper/AddressMapper.java
@@ -18,6 +18,8 @@ public interface AddressMapper {
     @Mapping(target = "id", ignore = true)
     Address mapToAddress(AddressDTO addressDTO);
 
+    AddressDTO mapToAddressDTO(Address address);
+
     default void updateAddressFromDTO(UpdateAddressDTO addressDTO, @MappingTarget Address address) {
         if(StringUtils.hasText(addressDTO.city())) {
             address.setCity(addressDTO.city());

--- a/src/main/java/com/example/petbuddybackend/service/mapper/CaretakerMapper.java
+++ b/src/main/java/com/example/petbuddybackend/service/mapper/CaretakerMapper.java
@@ -1,5 +1,6 @@
 package com.example.petbuddybackend.service.mapper;
 
+import com.example.petbuddybackend.dto.user.CaretakerComplexInfoDTO;
 import com.example.petbuddybackend.dto.user.CaretakerDTO;
 import com.example.petbuddybackend.dto.user.CreateCaretakerDTO;
 import com.example.petbuddybackend.dto.user.UpdateCaretakerDTO;
@@ -19,7 +20,7 @@ public interface CaretakerMapper {
     CaretakerMapper INSTANCE = Mappers.getMapper(CaretakerMapper.class);
 
     @Mapping(target = "animals", source = "offers", qualifiedByName = "mapAnimalFromOffer")
-    CaretakerDTO mapToCaretakerDTO(Caretaker caretaker);
+    CaretakerComplexInfoDTO mapToCaretakerComplexInfoDTO(Caretaker caretaker);
 
     @Named("mapAnimalFromOffer")
     default String mapAnimalFromOffer(Offer offer) {
@@ -27,6 +28,9 @@ public interface CaretakerMapper {
     }
 
     Caretaker mapToCaretaker(CreateCaretakerDTO caretakerDTO);
+
+    @Mapping(target = "animals", source = "offers", qualifiedByName = "mapAnimalFromOffer")
+    CaretakerDTO mapToCaretakerDTO(Caretaker caretaker);
 
     default void updateCaretakerFromDTO(UpdateCaretakerDTO caretakerDTO, @MappingTarget Caretaker caretaker) {
         if (StringUtils.hasText(caretakerDTO.phoneNumber())) {

--- a/src/main/java/com/example/petbuddybackend/service/offer/OfferService.java
+++ b/src/main/java/com/example/petbuddybackend/service/offer/OfferService.java
@@ -2,6 +2,8 @@ package com.example.petbuddybackend.service.offer;
 
 import com.example.petbuddybackend.dto.availability.AvailabilityRangeDTO;
 import com.example.petbuddybackend.dto.availability.CreateOffersAvailabilityDTO;
+import com.example.petbuddybackend.dto.offer.ModifyConfigurationDTO;
+import com.example.petbuddybackend.dto.offer.ModifyOfferDTO;
 import com.example.petbuddybackend.dto.offer.OfferConfigurationDTO;
 import com.example.petbuddybackend.dto.offer.OfferDTO;
 import com.example.petbuddybackend.entity.amenity.AnimalAmenity;
@@ -47,7 +49,7 @@ public class OfferService {
     private final OfferConfigurationMapper offerConfigurationMapper = OfferConfigurationMapper.INSTANCE;
 
     @Transactional
-    public OfferDTO addOrEditOffer(OfferDTO offer, String caretakerEmail) {
+    public OfferDTO addOrEditOffer(ModifyOfferDTO offer, String caretakerEmail) {
         Caretaker caretaker = caretakerService.getCaretakerByEmail(caretakerEmail);
 
         Offer modifiyngOffer = getOrCreateOffer(caretakerEmail, offer.animal().animalType(),
@@ -75,7 +77,7 @@ public class OfferService {
     }
 
     @Transactional
-    public OfferConfigurationDTO editConfiguration(Long configurationId, OfferConfigurationDTO configuration) {
+    public OfferConfigurationDTO editConfiguration(Long configurationId, ModifyConfigurationDTO configuration) {
 
         OfferConfiguration offerConfiguration = getOfferConfiguration(configurationId);
 
@@ -117,7 +119,7 @@ public class OfferService {
 
     }
 
-    private void setOfferConfigurations(OfferDTO offer, Offer modifiyngOffer) {
+    private void setOfferConfigurations(ModifyOfferDTO offer, Offer modifiyngOffer) {
 
         if(CollectionUtil.isNotEmpty(offer.offerConfigurations())) {
             List<OfferConfiguration> offerConfigurations = createAdditionalConfigurationsForOffer(offer.offerConfigurations(), modifiyngOffer);
@@ -127,10 +129,10 @@ public class OfferService {
 
     }
 
-    private List<OfferConfiguration> createAdditionalConfigurationsForOffer(List<OfferConfigurationDTO> offerConfigurations,
+    private List<OfferConfiguration> createAdditionalConfigurationsForOffer(List<ModifyConfigurationDTO> offerConfigurations,
                                                                             Offer offer) {
         List<OfferConfiguration> newOfferConfigurations = new ArrayList<>();
-        for(OfferConfigurationDTO offerConfiguration : offerConfigurations) {
+        for(ModifyConfigurationDTO offerConfiguration : offerConfigurations) {
             OfferConfiguration configuration = createConfiguration(offerConfiguration, offer);
             checkForDuplicateConfiguration(Stream.concat(
                     Optional.ofNullable(offer.getOfferConfigurations()).orElse(Collections.emptyList()).stream(),
@@ -170,7 +172,7 @@ public class OfferService {
 
     }
 
-    private OfferConfiguration createConfiguration(OfferConfigurationDTO offerConfiguration, Offer offer) {
+    private OfferConfiguration createConfiguration(ModifyConfigurationDTO offerConfiguration, Offer offer) {
         OfferConfiguration newOfferConfiguration = OfferConfiguration.builder()
                 .dailyPrice(offerConfiguration.dailyPrice())
                 .description(offerConfiguration.description())
@@ -207,7 +209,7 @@ public class OfferService {
                 .build();
     }
 
-    private void setOfferAnimalAmenities(OfferDTO offer, Offer modifiyngOffer) {
+    private void setOfferAnimalAmenities(ModifyOfferDTO offer, Offer modifiyngOffer) {
 
         if(CollectionUtil.isNotEmpty(offer.animalAmenities())) {
             Set<AnimalAmenity> animalAmenities = createAdditionalAnimalAmenitiesForOffer(offer.animalAmenities(), modifiyngOffer);
@@ -249,7 +251,7 @@ public class OfferService {
                 .orElseThrow(() -> new NotFoundException("Offer configuration with id " + id + " not found"));
     }
 
-    private void editConfigurationSelectedOptions(OfferConfiguration editingConfiguration, OfferConfigurationDTO configuration) {
+    private void editConfigurationSelectedOptions(OfferConfiguration editingConfiguration, ModifyConfigurationDTO configuration) {
         List<OfferOption> offerOptions = editingConfiguration.getOfferOptions();
 
         offerOptions.removeIf(offerOption ->

--- a/src/main/java/com/example/petbuddybackend/service/user/CaretakerService.java
+++ b/src/main/java/com/example/petbuddybackend/service/user/CaretakerService.java
@@ -3,6 +3,7 @@ package com.example.petbuddybackend.service.user;
 import com.example.petbuddybackend.dto.criteriaSearch.CaretakerSearchCriteria;
 import com.example.petbuddybackend.dto.offer.OfferFilterDTO;
 import com.example.petbuddybackend.dto.rating.RatingResponse;
+import com.example.petbuddybackend.dto.user.CaretakerComplexInfoDTO;
 import com.example.petbuddybackend.dto.user.CaretakerDTO;
 import com.example.petbuddybackend.dto.user.CreateCaretakerDTO;
 import com.example.petbuddybackend.dto.user.UpdateCaretakerDTO;
@@ -126,12 +127,12 @@ public class CaretakerService {
         }
     }
 
-    public CaretakerDTO addCaretaker(CreateCaretakerDTO caretaker, String email) {
+    public CaretakerComplexInfoDTO addCaretaker(CreateCaretakerDTO caretaker, String email) {
         assertCaretakerNotExists(email);
         AppUser appUser = userService.getAppUser(email);
         Caretaker caretakerToSave = caretakerMapper.mapToCaretaker(caretaker);
         setAccountData(caretakerToSave, appUser);
-        return caretakerMapper.mapToCaretakerDTO(caretakerRepository.save(caretakerToSave));
+        return caretakerMapper.mapToCaretakerComplexInfoDTO(caretakerRepository.save(caretakerToSave));
     }
 
     private void setAccountData(Caretaker caretaker, AppUser appUser) {
@@ -139,12 +140,12 @@ public class CaretakerService {
         caretaker.setAccountData(appUser);
     }
 
-    public CaretakerDTO editCaretaker(UpdateCaretakerDTO caretaker, String email) {
+    public CaretakerComplexInfoDTO editCaretaker(UpdateCaretakerDTO caretaker, String email) {
 
         AppUser appUser = userService.getAppUser(email);
         Caretaker caretakerToSave = getCaretakerByEmail(appUser.getEmail());
         caretakerMapper.updateCaretakerFromDTO(caretaker, caretakerToSave);
-        return caretakerMapper.mapToCaretakerDTO(caretakerRepository.save(caretakerToSave));
+        return caretakerMapper.mapToCaretakerComplexInfoDTO(caretakerRepository.save(caretakerToSave));
 
     }
 

--- a/src/test/java/com/example/petbuddybackend/controller/CaretakerControllerTest.java
+++ b/src/test/java/com/example/petbuddybackend/controller/CaretakerControllerTest.java
@@ -25,7 +25,7 @@ import java.util.List;
 import java.util.stream.Stream;
 
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.Mockito.*;
+import static org.mockito.Mockito.when;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
@@ -51,18 +51,18 @@ public class CaretakerControllerTest {
 
     @Test
     void getCaretakers_shouldReturnFilteredResults() throws Exception {
-        CaretakerDTO caretakerDTO1 = CaretakerDTO.builder()
+        CaretakerDTO caretakerComplexInfoDTO1 = CaretakerDTO.builder()
                 .accountData(AccountDataDTO.builder().name("John Doe").build())
                 .build();
 
-        CaretakerDTO caretakerDTO2 = CaretakerDTO.builder()
+        CaretakerDTO caretakerComplexInfoDTO2 = CaretakerDTO.builder()
                 .accountData(AccountDataDTO.builder().name("Jane Doe").build())
                 .build();
 
-        List<CaretakerDTO> caretakerDTOs = List.of(caretakerDTO1, caretakerDTO2);
+        List<CaretakerDTO> caretakerComplexInfoDTOS = List.of(caretakerComplexInfoDTO1, caretakerComplexInfoDTO2);
         Page<CaretakerDTO> page = new PageImpl<>(
-                caretakerDTOs,
-                PageRequest.of(0, 10), caretakerDTOs.size()
+                caretakerComplexInfoDTOS,
+                PageRequest.of(0, 10), caretakerComplexInfoDTOS.size()
         );
 
         when(caretakerService.getCaretakers(any(), any(), any())).thenReturn(page);

--- a/src/test/java/com/example/petbuddybackend/controller/OfferControllerTest.java
+++ b/src/test/java/com/example/petbuddybackend/controller/OfferControllerTest.java
@@ -59,6 +59,24 @@ public class OfferControllerTest {
         }
         """;
 
+    private static final String CREATE_OR_UPDATE_OFFER = """
+        {
+            "description": "%s",
+            "animal": {
+                "animalType": "%s"
+            }
+        }
+        """;
+
+    private static final String CREATE_OR_UPDATE_CONFIGURATION = """
+        {
+            "description": "%s",
+            "dailyPrice": 10.0,
+            "selectedOptions": {
+                "SIZE": ["BIG"]
+            }
+        }
+        """;
 
     @Test
     @WithMockUser
@@ -78,7 +96,9 @@ public class OfferControllerTest {
         // When and Then
         mockMvc.perform(post("/api/caretaker/offer/add-or-edit")
                         .contentType(MediaType.APPLICATION_JSON)
-                        .content("{\"description\": \"Test Offer\"}"))
+                        .content(String.format(CREATE_OR_UPDATE_OFFER,
+                                "Test Offer",
+                                "DOG")))
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.description").value("Test Offer"))
                 .andExpect(jsonPath("$.offerConfigurations[0].description").value("Test Configuration"))
@@ -97,7 +117,7 @@ public class OfferControllerTest {
         // When and Then
         mockMvc.perform(post("/api/caretaker/offer/configuration/1/edit")
                         .contentType(MediaType.APPLICATION_JSON)
-                        .content("{\"description\": \"Updated Configuration\"}"))
+                        .content(String.format(CREATE_OR_UPDATE_CONFIGURATION, "Updated Configuration")))
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.description").value("Updated Configuration"));
 

--- a/src/test/java/com/example/petbuddybackend/controller/OfferControllerTest.java
+++ b/src/test/java/com/example/petbuddybackend/controller/OfferControllerTest.java
@@ -1,6 +1,8 @@
 package com.example.petbuddybackend.controller;
 
 import com.example.petbuddybackend.dto.availability.AvailabilityRangeDTO;
+import com.example.petbuddybackend.dto.offer.ModifyConfigurationDTO;
+import com.example.petbuddybackend.dto.offer.ModifyOfferDTO;
 import com.example.petbuddybackend.dto.offer.OfferConfigurationDTO;
 import com.example.petbuddybackend.dto.offer.OfferDTO;
 import com.example.petbuddybackend.service.offer.OfferService;
@@ -71,7 +73,7 @@ public class OfferControllerTest {
                                 .build()
                 ))
                 .build();
-        when(offerService.addOrEditOffer(any(OfferDTO.class), anyString())).thenReturn(offerDTO);
+        when(offerService.addOrEditOffer(any(ModifyOfferDTO.class), anyString())).thenReturn(offerDTO);
 
         // When and Then
         mockMvc.perform(post("/api/caretaker/offer/add-or-edit")
@@ -82,7 +84,7 @@ public class OfferControllerTest {
                 .andExpect(jsonPath("$.offerConfigurations[0].description").value("Test Configuration"))
                 .andExpect(jsonPath("$.offerConfigurations[0].selectedOptions.SIZE[0]").value("BIG"));
 
-        verify(offerService, times(1)).addOrEditOffer(any(OfferDTO.class), anyString());
+        verify(offerService, times(1)).addOrEditOffer(any(ModifyOfferDTO.class), anyString());
     }
 
     @Test
@@ -90,7 +92,7 @@ public class OfferControllerTest {
     void editConfiguration_ShouldReturnUpdatedConfiguration() throws Exception {
         // Given
         OfferConfigurationDTO configDTO = OfferConfigurationDTO.builder().description("Updated Configuration").build();
-        when(offerService.editConfiguration(anyLong(), any(OfferConfigurationDTO.class))).thenReturn(configDTO);
+        when(offerService.editConfiguration(anyLong(), any(ModifyConfigurationDTO.class))).thenReturn(configDTO);
 
         // When and Then
         mockMvc.perform(post("/api/caretaker/offer/configuration/1/edit")
@@ -99,7 +101,7 @@ public class OfferControllerTest {
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.description").value("Updated Configuration"));
 
-        verify(offerService, times(1)).editConfiguration(anyLong(), any(OfferConfigurationDTO.class));
+        verify(offerService, times(1)).editConfiguration(anyLong(), any(ModifyConfigurationDTO.class));
     }
 
     @Test

--- a/src/test/java/com/example/petbuddybackend/service/mapper/CaretakerMapperTest.java
+++ b/src/test/java/com/example/petbuddybackend/service/mapper/CaretakerMapperTest.java
@@ -1,6 +1,6 @@
 package com.example.petbuddybackend.service.mapper;
 
-import com.example.petbuddybackend.dto.user.CaretakerDTO;
+import com.example.petbuddybackend.dto.user.CaretakerComplexInfoDTO;
 import com.example.petbuddybackend.entity.user.Caretaker;
 import com.example.petbuddybackend.testutils.ValidationUtils;
 import com.example.petbuddybackend.testutils.mock.MockOfferProvider;
@@ -23,9 +23,9 @@ public class CaretakerMapperTest {
         setIds(caretaker);
         setCalculatedFields(caretaker);
 
-        CaretakerDTO caretakerDTO = mapper.mapToCaretakerDTO(caretaker);
+        CaretakerComplexInfoDTO caretakerComplexInfoDTO = mapper.mapToCaretakerComplexInfoDTO(caretaker);
 
-        assertTrue(ValidationUtils.fieldsNotNullRecursive(caretakerDTO));
+        assertTrue(ValidationUtils.fieldsNotNullRecursive(caretakerComplexInfoDTO));
     }
 
     private void setIds(Caretaker caretaker) {

--- a/src/test/java/com/example/petbuddybackend/service/offer/OfferServiceIntegrationTest.java
+++ b/src/test/java/com/example/petbuddybackend/service/offer/OfferServiceIntegrationTest.java
@@ -3,6 +3,8 @@ package com.example.petbuddybackend.service.offer;
 
 import com.example.petbuddybackend.dto.availability.AvailabilityRangeDTO;
 import com.example.petbuddybackend.dto.availability.CreateOffersAvailabilityDTO;
+import com.example.petbuddybackend.dto.offer.ModifyConfigurationDTO;
+import com.example.petbuddybackend.dto.offer.ModifyOfferDTO;
 import com.example.petbuddybackend.repository.AvailabilityRepository;
 import com.example.petbuddybackend.testconfig.TestDataConfiguration;
 import com.example.petbuddybackend.dto.animal.AnimalDTO;
@@ -111,7 +113,7 @@ public class OfferServiceIntegrationTest {
     @ParameterizedTest
     @MethodSource("provideOfferConfigurations")
     void addOrEditOffer_ShouldAddOrEditOfferWithProperData(
-            OfferDTO offerToSave, boolean expectedToBeExistingOffer, int expectedNumberOfConfigurationsAfterAddition,
+            ModifyOfferDTO offerToSave, boolean expectedToBeExistingOffer, int expectedNumberOfConfigurationsAfterAddition,
             int expectedNumberOfAnimalAmenities) {
 
         if(!expectedToBeExistingOffer) {
@@ -137,12 +139,12 @@ public class OfferServiceIntegrationTest {
     static Stream<Arguments> provideOfferConfigurations() {
         return Stream.of(
                 Arguments.of(
-                        OfferDTO.builder()
+                        ModifyOfferDTO.builder()
                                 .description("First Configuration")
                                 .animal(AnimalDTO.builder().animalType("DOG").build())
                                 .offerConfigurations(
                                         new ArrayList<>(List.of(
-                                                OfferConfigurationDTO.builder()
+                                                ModifyConfigurationDTO.builder()
                                                         .description("First Description")
                                                         .dailyPrice(BigDecimal.valueOf(20.0))
                                                         .selectedOptions(new HashMap<>(Map.of("SIZE", new ArrayList<>(List.of("BIG")))))
@@ -155,12 +157,12 @@ public class OfferServiceIntegrationTest {
                         0 // Expected number of animal amenities
                 ),
                 Arguments.of(
-                        OfferDTO.builder()
+                        ModifyOfferDTO.builder()
                                 .description("Second Configuration")
                                 .animal(AnimalDTO.builder().animalType("DOG").build())
                                 .offerConfigurations(
                                         new ArrayList<>(List.of(
-                                                OfferConfigurationDTO.builder()
+                                                ModifyConfigurationDTO.builder()
                                                         .description("Second Description")
                                                         .dailyPrice(BigDecimal.valueOf(30.0))
                                                         .selectedOptions(new HashMap<>(Map.of("SIZE", new ArrayList<>(List.of("SMALL")))))
@@ -173,12 +175,12 @@ public class OfferServiceIntegrationTest {
                         1 // Expected number of animal amenities
                 ),
                 Arguments.of(
-                        OfferDTO.builder()
+                        ModifyOfferDTO.builder()
                                 .description("Third Configuration")
                                 .animal(AnimalDTO.builder().animalType("DOG").build())
                                 .offerConfigurations(
                                         new ArrayList<>(List.of(
-                                                OfferConfigurationDTO.builder()
+                                                ModifyConfigurationDTO.builder()
                                                         .description("Second Description")
                                                         .dailyPrice(BigDecimal.valueOf(30.0))
                                                         .selectedOptions(new HashMap<>(Map.of("SIZE", new ArrayList<>(List.of("SMALL")))))
@@ -192,7 +194,7 @@ public class OfferServiceIntegrationTest {
                         2 // Expected number of animal amenities
                 ),
                 Arguments.of(
-                        OfferDTO.builder()
+                        ModifyOfferDTO.builder()
                                 .description("Third Configuration")
                                 .animal(AnimalDTO.builder().animalType("DOG").build())
                                 .animalAmenities(new ArrayList<>(List.of("garden")))
@@ -209,7 +211,7 @@ public class OfferServiceIntegrationTest {
     @MethodSource("provideEditConfigurationScenarios")
     @Transactional
     void editConfiguration_ShouldEditConfigurationWithProperData(
-            int configurationIndex, OfferConfigurationDTO configurationToEdit, String expectedDescription,
+            int configurationIndex, ModifyConfigurationDTO configurationToEdit, String expectedDescription,
             BigDecimal expectedDailyPrice, Map<String, List<String>> expectedSelectedOptions) {
 
         Long configurationId = existingOffer.getOfferConfigurations().get(configurationIndex).getId();
@@ -244,7 +246,7 @@ public class OfferServiceIntegrationTest {
         return Stream.of(
                 Arguments.of(
                         0, // ID of the configuration to edit
-                        OfferConfigurationDTO.builder()
+                        ModifyConfigurationDTO.builder()
                                 .description("Updated Description")
                                 .dailyPrice(BigDecimal.valueOf(25.0))
                                 .selectedOptions(new HashMap<>(Map.of(
@@ -258,7 +260,7 @@ public class OfferServiceIntegrationTest {
                 ),
                 Arguments.of(
                         0, // ID of the configuration to edit
-                        OfferConfigurationDTO.builder()
+                        ModifyConfigurationDTO.builder()
                                 .description("Another Update")
                                 .dailyPrice(BigDecimal.valueOf(30.0))
                                 .selectedOptions(new HashMap<>(Map.of(
@@ -280,7 +282,7 @@ public class OfferServiceIntegrationTest {
     @ParameterizedTest
     @MethodSource("provideIncorrectOfferConfigurations")
     void addOrEditOffer_ShouldThrowException(
-            OfferDTO offerToSave, boolean expectedToBeExistingOffer, Class expectedExceptionClass) {
+            ModifyOfferDTO offerToSave, boolean expectedToBeExistingOffer, Class expectedExceptionClass) {
 
         if(!expectedToBeExistingOffer) {
             offerRepository.delete(existingOffer);
@@ -295,12 +297,12 @@ public class OfferServiceIntegrationTest {
     static Stream<Arguments> provideIncorrectOfferConfigurations() {
         return Stream.of(
                 Arguments.of(
-                        OfferDTO.builder()
+                        ModifyOfferDTO.builder()
                                 .description("First Configuration")
                                 .animal(AnimalDTO.builder().animalType("SOME ANIMAL").build())
                                 .offerConfigurations(
                                         new ArrayList<>(List.of(
-                                                OfferConfigurationDTO.builder()
+                                                ModifyConfigurationDTO.builder()
                                                         .description("First Description")
                                                         .dailyPrice(BigDecimal.valueOf(20.0))
                                                         .selectedOptions(new HashMap<>(Map.of("SIZE", new ArrayList<>(List.of("BIG")))))
@@ -312,12 +314,12 @@ public class OfferServiceIntegrationTest {
                         NotFoundException.class
                 ),
                 Arguments.of(
-                        OfferDTO.builder()
+                        ModifyOfferDTO.builder()
                                 .description("Second Configuration")
                                 .animal(AnimalDTO.builder().animalType("DOG").build())
                                 .offerConfigurations(
                                         new ArrayList<>(List.of(
-                                                OfferConfigurationDTO.builder()
+                                                ModifyConfigurationDTO.builder()
                                                         .description("Second Description")
                                                         .dailyPrice(BigDecimal.valueOf(30.0))
                                                         .selectedOptions(new HashMap<>(
@@ -333,7 +335,7 @@ public class OfferServiceIntegrationTest {
                         OfferConfigurationDuplicatedException.class
                 ),
                 Arguments.of(
-                        OfferDTO.builder()
+                        ModifyOfferDTO.builder()
                                 .description("Third Configuration")
                                 .animal(AnimalDTO.builder().animalType("DOG").build())
                                 .animalAmenities(new ArrayList<>(List.of("not found amenity")))
@@ -348,7 +350,7 @@ public class OfferServiceIntegrationTest {
     @MethodSource("provideIncorrectEditConfigurationScenarios")
     @Transactional
     void editConfiguration_ShouldThrowAnException(
-            int configurationIndex, OfferConfigurationDTO configurationToEdit, Class expectedExceptionClass) {
+            int configurationIndex, ModifyConfigurationDTO configurationToEdit, Class expectedExceptionClass) {
 
         Long configurationId = existingOffer.getOfferConfigurations().get(configurationIndex).getId();
 
@@ -365,7 +367,7 @@ public class OfferServiceIntegrationTest {
         return Stream.of(
                 Arguments.of(
                         0, // ID of the configuration to edit
-                        OfferConfigurationDTO.builder()
+                        ModifyConfigurationDTO.builder()
                                 .description("Updated Description")
                                 .dailyPrice(BigDecimal.valueOf(25.0))
                                 .selectedOptions(new HashMap<>(Map.of(

--- a/src/test/java/com/example/petbuddybackend/service/offer/OfferServiceUnitTest.java
+++ b/src/test/java/com/example/petbuddybackend/service/offer/OfferServiceUnitTest.java
@@ -1,7 +1,7 @@
 package com.example.petbuddybackend.service.offer;
 
 import com.example.petbuddybackend.dto.animal.AnimalDTO;
-import com.example.petbuddybackend.dto.offer.OfferDTO;
+import com.example.petbuddybackend.dto.offer.ModifyOfferDTO;
 import com.example.petbuddybackend.entity.animal.Animal;
 import com.example.petbuddybackend.entity.offer.Offer;
 import com.example.petbuddybackend.entity.user.Caretaker;
@@ -21,7 +21,8 @@ import java.util.Optional;
 import static com.example.petbuddybackend.testutils.mock.MockAnimalProvider.createMockAnimal;
 import static com.example.petbuddybackend.testutils.mock.MockOfferProvider.createMockOffer;
 import static com.example.petbuddybackend.testutils.mock.MockUserProvider.createMockCaretaker;
-import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.mockito.Mockito.*;
 
 @ExtendWith(MockitoExtension.class)
@@ -57,7 +58,7 @@ public class OfferServiceUnitTest {
     void addOrEditOffer_WhenOfferDoesNotExists_ShouldCreateNewOffer() {
 
         // Given
-        OfferDTO offerToCreate = OfferDTO.builder()
+        ModifyOfferDTO offerToCreate = ModifyOfferDTO.builder()
                 .description("description")
                 .animal(AnimalDTO.builder().animalType("DOG").build())
                 .build();

--- a/src/test/java/com/example/petbuddybackend/service/user/CaretakerServiceTest.java
+++ b/src/test/java/com/example/petbuddybackend/service/user/CaretakerServiceTest.java
@@ -6,10 +6,7 @@ import com.example.petbuddybackend.dto.criteriaSearch.CaretakerSearchCriteria;
 import com.example.petbuddybackend.dto.offer.OfferConfigurationFilterDTO;
 import com.example.petbuddybackend.dto.offer.OfferFilterDTO;
 import com.example.petbuddybackend.dto.rating.RatingResponse;
-import com.example.petbuddybackend.dto.user.AccountDataDTO;
-import com.example.petbuddybackend.dto.user.CaretakerDTO;
-import com.example.petbuddybackend.dto.user.CreateCaretakerDTO;
-import com.example.petbuddybackend.dto.user.UpdateCaretakerDTO;
+import com.example.petbuddybackend.dto.user.*;
 import com.example.petbuddybackend.entity.address.Voivodeship;
 import com.example.petbuddybackend.entity.offer.Offer;
 import com.example.petbuddybackend.entity.rating.Rating;
@@ -808,7 +805,7 @@ public class CaretakerServiceTest {
 
     @Test
     void testGetCaretakers_sortingParamsShouldAlignWithDTO() {
-        List<String> fieldNames = ReflectionUtils.getPrimitiveNames(CaretakerDTO.class);
+        List<String> fieldNames = ReflectionUtils.getPrimitiveNames(CaretakerComplexInfoDTO.class);
         fieldNames.addAll(getPrimitiveNames(AddressDTO.class, "address_"));
         fieldNames.addAll(getPrimitiveNames(AccountDataDTO.class, "accountData_"));
 
@@ -1013,7 +1010,7 @@ public class CaretakerServiceTest {
                 .build();
 
         //When
-        CaretakerDTO result = caretakerService.addCaretaker(caretakerToCreate, appUser.getEmail());
+        CaretakerComplexInfoDTO result = caretakerService.addCaretaker(caretakerToCreate, appUser.getEmail());
         Caretaker caretaker = caretakerRepository.findById(result.accountData().email()).orElse(null);
 
         //Then
@@ -1094,7 +1091,7 @@ public class CaretakerServiceTest {
         String oldZipCode = caretakerWithComplexOffer.getAddress().getZipCode();
 
         //When
-        CaretakerDTO result = caretakerService.editCaretaker(caretakerToCreate, caretakerWithComplexOffer.getEmail());
+        CaretakerComplexInfoDTO result = caretakerService.editCaretaker(caretakerToCreate, caretakerWithComplexOffer.getEmail());
         Caretaker caretaker = caretakerRepository.findById(result.accountData().email()).orElse(null);
 
         //Then
@@ -1154,7 +1151,7 @@ public class CaretakerServiceTest {
                 .build();
 
         //When
-        CaretakerDTO result = caretakerService.editCaretaker(caretakerToCreate, caretakerWithComplexOffer.getEmail());
+        CaretakerComplexInfoDTO result = caretakerService.editCaretaker(caretakerToCreate, caretakerWithComplexOffer.getEmail());
         Caretaker caretaker = caretakerRepository.findById(result.accountData().email()).orElse(null);
 
         //Then


### PR DESCRIPTION
Rozdzielenie objektów DTO przyjmowanych w przypadku edytowania oferty i w przypadku zwracania oferty dla frontu.
Przy wyszukiwaniu opiekunów zwracamy teraz tylko podstawowe informacje o opiekunie bez ofert i innych bardziej szczegółowych informacji.