### PR TITLE
Cyndzer/ZPI-37-ZPI-21-BE-18-BE-44-Firebase-storage-integration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,3 +31,6 @@ build/
 
 ### VS Code ###
 .vscode/
+
+/secret/**
+!/secret/.gitkeep

--- a/pom.xml
+++ b/pom.xml
@@ -128,6 +128,16 @@
             <artifactId>spring-security-test</artifactId>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>com.google.firebase</groupId>
+            <artifactId>firebase-admin</artifactId>
+            <version>9.2.0</version>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.tika</groupId>
+            <artifactId>tika-core</artifactId>
+            <version>2.9.2</version>
+        </dependency>
     </dependencies>
 
     <build>
@@ -148,6 +158,7 @@
                             <exclude>com/example/petbuddybackend/config/security/**</exclude>
                             <exclude>com/example/petbuddybackend/config/websocket/**</exclude>
                             <exclude>com/example/petbuddybackend/config/web/WebConfig.class</exclude>
+                            <exclude>com/example/petbuddybackend/config/firebase/**</exclude>
                             <exclude>com/example/petbuddybackend/service/datageneration/**</exclude>
                             <exclude>com/example/petbuddybackend/filter/ExceptionHandlerFilter.class</exclude>
                             <exclude>com/example/petbuddybackend/filter/CORSFilter.class</exclude>

--- a/src/main/java/com/example/petbuddybackend/config/datageneration/MockDataCreator.java
+++ b/src/main/java/com/example/petbuddybackend/config/datageneration/MockDataCreator.java
@@ -13,7 +13,7 @@ import com.example.petbuddybackend.entity.user.AppUser;
 import com.example.petbuddybackend.entity.user.Caretaker;
 import com.example.petbuddybackend.entity.user.Client;
 import com.example.petbuddybackend.entity.user.Role;
-import com.example.petbuddybackend.repository.AvailabilityRepository;
+import com.example.petbuddybackend.repository.availability.AvailabilityRepository;
 import com.example.petbuddybackend.repository.amenity.AnimalAmenityRepository;
 import com.example.petbuddybackend.repository.animal.AnimalAttributeRepository;
 import com.example.petbuddybackend.repository.animal.AnimalRepository;

--- a/src/main/java/com/example/petbuddybackend/config/firebase/FirebaseConfig.java
+++ b/src/main/java/com/example/petbuddybackend/config/firebase/FirebaseConfig.java
@@ -1,0 +1,88 @@
+package com.example.petbuddybackend.config.firebase;
+
+import com.google.auth.oauth2.GoogleCredentials;
+import com.google.firebase.FirebaseApp;
+import com.google.firebase.FirebaseOptions;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Profile;
+import org.springframework.util.StringUtils;
+
+import java.io.*;
+
+@Slf4j
+@Profile("!test")
+@Configuration
+@RequiredArgsConstructor
+public class FirebaseConfig {
+
+    @Value("${firebase.key.path}")
+    private String FIREBASE_SERVICE_ACCOUNT_KEY_PATH;
+
+    @Value("${FIREBASE_APPLICATION_CREDENTIALS:#{null}}")
+    private String FIREBASE_SERVICE_ACCOUNT_KEY_ENV_VARIABLE;
+
+    @Value("${firebase.bucket.link}")
+    private String FIREBASE_BUCKET_LINK;
+
+    @Value("${firebase.project.id}")
+    private String FIREBASE_PROJECT_ID;
+
+    private static boolean initialized = false;
+
+    @Bean
+    public FirebaseApp firebaseApp() {
+        if(initialized) {
+            log.info("Firebase SDK already initialized!");
+            return FirebaseApp.getInstance();
+        }
+
+        log.info("Initializing Firebase SDK...");
+
+        FirebaseOptions options = FirebaseOptions.builder()
+                .setCredentials(createCredentials())
+                .setStorageBucket(FIREBASE_BUCKET_LINK)
+                .setProjectId(FIREBASE_PROJECT_ID)
+                .build();
+
+        FirebaseApp app = FirebaseApp.initializeApp(options);
+        log.info("Firebase SDK initialized!");
+        initialized = true;
+        return app;
+    }
+
+    private GoogleCredentials createCredentials() {
+        File firebaseCredentialsFile = new File(FIREBASE_SERVICE_ACCOUNT_KEY_PATH);
+
+        return firebaseCredentialsFile.exists() ?
+                createCredentialsFromFile(firebaseCredentialsFile) :
+                createCredentialsFromEnvVariable();
+    }
+
+    private GoogleCredentials createCredentialsFromFile(File file) {
+        log.info("Reading Firebase service account key file...");
+
+        try(InputStream serviceAccount = new FileInputStream(file)) {
+            return GoogleCredentials.fromStream(serviceAccount);
+        } catch(IOException e) {
+            throw new RuntimeException("Error while reading Firebase service account key file", e);
+        }
+    }
+
+    private GoogleCredentials createCredentialsFromEnvVariable() {
+        log.info("Reading Firebase service account key from env variable...");
+
+        if(!StringUtils.hasText(FIREBASE_SERVICE_ACCOUNT_KEY_ENV_VARIABLE)) {
+            throw new RuntimeException("Firebase service account key is not provided as env variable");
+        }
+
+        try(ByteArrayInputStream inputStream = new ByteArrayInputStream(FIREBASE_SERVICE_ACCOUNT_KEY_ENV_VARIABLE.getBytes())) {
+            return GoogleCredentials.fromStream(inputStream);
+        } catch(IOException e) {
+            throw new RuntimeException("Error while reading Firebase service account key from env variable", e);
+        }
+    }
+}

--- a/src/main/java/com/example/petbuddybackend/config/firebase/FirebaseConfig.java
+++ b/src/main/java/com/example/petbuddybackend/config/firebase/FirebaseConfig.java
@@ -14,7 +14,7 @@ import org.springframework.util.StringUtils;
 import java.io.*;
 
 @Slf4j
-@Profile("!test")
+@Profile("dev | prod")
 @Configuration
 @RequiredArgsConstructor
 public class FirebaseConfig {

--- a/src/main/java/com/example/petbuddybackend/config/firebase/FirebasePhotosCleaner.java
+++ b/src/main/java/com/example/petbuddybackend/config/firebase/FirebasePhotosCleaner.java
@@ -1,0 +1,71 @@
+package com.example.petbuddybackend.config.firebase;
+
+import com.google.cloud.storage.Blob;
+import com.google.firebase.FirebaseApp;
+import com.google.firebase.cloud.StorageClient;
+import jakarta.annotation.PostConstruct;
+import jakarta.annotation.PreDestroy;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Profile;
+import org.springframework.core.env.Environment;
+import org.springframework.stereotype.Component;
+
+import java.util.Iterator;
+import java.util.concurrent.atomic.AtomicInteger;
+
+
+@Slf4j
+@Component
+@Profile("dev")
+@RequiredArgsConstructor
+public class FirebasePhotosCleaner  {
+
+    private static final String CREATE_DROP = "create-drop";
+    private static final String SPRING_JPA_HIBERNATE_DDL_AUTO = "spring.jpa.hibernate.ddl-auto";
+
+    @Value("${firebase.photo.directory}")
+    private String PHOTO_DIRECTORY;
+
+    private final FirebaseApp firebaseApp;
+    private final Environment environment;
+
+    @PreDestroy
+    @PostConstruct
+    public void photosCleanup() {
+        if (isCreateDropEnabled()) {
+            log.warn("Firebase storage cleanup is enabled. Cleaning up...");
+            cleanupPhotosFromFirebase();
+        }
+    }
+
+    private boolean isCreateDropEnabled() {
+        String ddlAuto = environment.getProperty(SPRING_JPA_HIBERNATE_DDL_AUTO);
+        return CREATE_DROP.equalsIgnoreCase(ddlAuto);
+    }
+
+    private void cleanupPhotosFromFirebase() {
+        log.info("Cleaning Firebase storage...");
+        AtomicInteger successCount = new AtomicInteger();
+        StorageClient storageClient = StorageClient.getInstance(firebaseApp);
+        Iterator<Blob> blobs = storageClient.bucket()
+                .list()
+                .iterateAll()
+                .iterator();
+
+        blobs.forEachRemaining(blob -> {
+            try {
+                if (blob.getName().startsWith(PHOTO_DIRECTORY)) {
+                    blob.delete();
+                    log.trace("Deleted photo from Firebase: {}", blob.getName());
+                    successCount.getAndIncrement();
+                }
+            } catch (Exception e) {
+                log.error("Error while deleting photo: {}", blob.getName(), e);
+            }
+        });
+
+        log.info("Deleted {} photos from Firebase storage", successCount.get());
+    }
+}

--- a/src/main/java/com/example/petbuddybackend/config/tika/TikaConfig.java
+++ b/src/main/java/com/example/petbuddybackend/config/tika/TikaConfig.java
@@ -1,0 +1,14 @@
+package com.example.petbuddybackend.config.tika;
+
+import org.apache.tika.Tika;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class TikaConfig {
+
+    @Bean
+    public Tika tika() {
+        return new Tika();
+    }
+}

--- a/src/main/java/com/example/petbuddybackend/controller/ChatWebSocketController.java
+++ b/src/main/java/com/example/petbuddybackend/controller/ChatWebSocketController.java
@@ -94,10 +94,6 @@ public class ChatWebSocketController {
         StompHeaderAccessor accessor = StompHeaderAccessor.wrap(event.getMessage());
         String destination = accessor.getDestination();
 
-        if(!HeaderUtils.destinationStartsWith(URL_CHAT_TOPIC_BASE, destination)) {
-            return;
-        }
-
         if(!sessionContext.containsSubscriptionId(accessor.getSubscriptionId()) || sessionContext.isEmpty()) {
             return;
         }

--- a/src/main/java/com/example/petbuddybackend/entity/photo/CloudPhoto.java
+++ b/src/main/java/com/example/petbuddybackend/entity/photo/CloudPhoto.java
@@ -1,0 +1,29 @@
+package com.example.petbuddybackend.entity.photo;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EntityListeners;
+import jakarta.persistence.Id;
+import lombok.*;
+
+import java.time.LocalDateTime;
+
+@Data
+@Entity
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+@EqualsAndHashCode(of = "blob")
+@EntityListeners(CloudPhotoDeleteListener.class)
+public class CloudPhoto {
+
+    @Id
+    @Column(nullable = false, length = 64, unique = true)
+    private String blob;
+
+    @Column(nullable = false, length = 1024)
+    private String url;
+
+    @Column(nullable = false)
+    private LocalDateTime urlExpiresAt;
+}

--- a/src/main/java/com/example/petbuddybackend/entity/photo/CloudPhotoDeleteListener.java
+++ b/src/main/java/com/example/petbuddybackend/entity/photo/CloudPhotoDeleteListener.java
@@ -1,0 +1,24 @@
+package com.example.petbuddybackend.entity.photo;
+
+import com.google.firebase.FirebaseApp;
+import com.google.firebase.cloud.StorageClient;
+import jakarta.persistence.PreRemove;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class CloudPhotoDeleteListener {
+
+    private final FirebaseApp firebaseApp;
+
+    @PreRemove
+    public void removePhotoFromRemote(CloudPhoto photo) {
+        StorageClient storageClient = StorageClient.getInstance(firebaseApp);
+        var bucket = storageClient.bucket();
+        var blobToDelete = bucket.get(photo.getBlob());
+
+        if(blobToDelete != null)
+            blobToDelete.delete();
+    }
+}

--- a/src/main/java/com/example/petbuddybackend/entity/photo/CloudPhotoDeleteListener.java
+++ b/src/main/java/com/example/petbuddybackend/entity/photo/CloudPhotoDeleteListener.java
@@ -1,5 +1,7 @@
 package com.example.petbuddybackend.entity.photo;
 
+import com.google.cloud.storage.Blob;
+import com.google.cloud.storage.Bucket;
 import com.google.firebase.FirebaseApp;
 import com.google.firebase.cloud.StorageClient;
 import jakarta.persistence.PreRemove;
@@ -15,10 +17,11 @@ public class CloudPhotoDeleteListener {
     @PreRemove
     public void removePhotoFromRemote(CloudPhoto photo) {
         StorageClient storageClient = StorageClient.getInstance(firebaseApp);
-        var bucket = storageClient.bucket();
-        var blobToDelete = bucket.get(photo.getBlob());
+        Bucket bucket = storageClient.bucket();
+        Blob blobToDelete = bucket.get(photo.getBlob());
 
-        if(blobToDelete != null)
+        if(blobToDelete != null) {
             blobToDelete.delete();
+        }
     }
 }

--- a/src/main/java/com/example/petbuddybackend/entity/photo/PhotoLink.java
+++ b/src/main/java/com/example/petbuddybackend/entity/photo/PhotoLink.java
@@ -14,8 +14,8 @@ import java.time.LocalDateTime;
 @NoArgsConstructor
 @AllArgsConstructor
 @EqualsAndHashCode(of = "blob")
-@EntityListeners(CloudPhotoDeleteListener.class)
-public class CloudPhoto {
+@EntityListeners(PhotoLinkDeleteListener.class)
+public class PhotoLink {
 
     @Id
     @Column(nullable = false, length = 64, unique = true)

--- a/src/main/java/com/example/petbuddybackend/entity/photo/PhotoLinkDeleteListener.java
+++ b/src/main/java/com/example/petbuddybackend/entity/photo/PhotoLinkDeleteListener.java
@@ -10,12 +10,12 @@ import org.springframework.stereotype.Component;
 
 @Component
 @RequiredArgsConstructor
-public class CloudPhotoDeleteListener {
+public class PhotoLinkDeleteListener {
 
     private final FirebaseApp firebaseApp;
 
     @PreRemove
-    public void removePhotoFromRemote(CloudPhoto photo) {
+    public void removePhotoFromRemote(PhotoLink photo) {
         StorageClient storageClient = StorageClient.getInstance(firebaseApp);
         Bucket bucket = storageClient.bucket();
         Blob blobToDelete = bucket.get(photo.getBlob());

--- a/src/main/java/com/example/petbuddybackend/repository/availability/AvailabilityRepository.java
+++ b/src/main/java/com/example/petbuddybackend/repository/availability/AvailabilityRepository.java
@@ -1,4 +1,4 @@
-package com.example.petbuddybackend.repository;
+package com.example.petbuddybackend.repository.availability;
 
 import com.example.petbuddybackend.entity.availability.Availability;
 import org.springframework.data.jpa.repository.JpaRepository;

--- a/src/main/java/com/example/petbuddybackend/repository/photo/CloudPhotoRepository.java
+++ b/src/main/java/com/example/petbuddybackend/repository/photo/CloudPhotoRepository.java
@@ -1,0 +1,9 @@
+package com.example.petbuddybackend.repository.photo;
+
+import com.example.petbuddybackend.entity.photo.CloudPhoto;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface CloudPhotoRepository extends JpaRepository<CloudPhoto, String> {
+}

--- a/src/main/java/com/example/petbuddybackend/repository/photo/PhotoLinkRepository.java
+++ b/src/main/java/com/example/petbuddybackend/repository/photo/PhotoLinkRepository.java
@@ -1,9 +1,9 @@
 package com.example.petbuddybackend.repository.photo;
 
-import com.example.petbuddybackend.entity.photo.CloudPhoto;
+import com.example.petbuddybackend.entity.photo.PhotoLink;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
 @Repository
-public interface CloudPhotoRepository extends JpaRepository<CloudPhoto, String> {
+public interface PhotoLinkRepository extends JpaRepository<PhotoLink, String> {
 }

--- a/src/main/java/com/example/petbuddybackend/service/image/FirebasePhotoService.java
+++ b/src/main/java/com/example/petbuddybackend/service/image/FirebasePhotoService.java
@@ -1,0 +1,157 @@
+package com.example.petbuddybackend.service.image;
+
+import com.example.petbuddybackend.entity.photo.CloudPhoto;
+import com.example.petbuddybackend.repository.photo.CloudPhotoRepository;
+import com.example.petbuddybackend.utils.exception.throweable.general.NotFoundException;
+import com.example.petbuddybackend.utils.exception.throweable.photo.InvalidPhotoException;
+import com.google.cloud.storage.Blob;
+import com.google.cloud.storage.Bucket;
+import com.google.firebase.FirebaseApp;
+import com.google.firebase.cloud.StorageClient;
+import lombok.RequiredArgsConstructor;
+import org.apache.tika.Tika;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.time.LocalDateTime;
+import java.util.*;
+import java.util.concurrent.TimeUnit;
+
+
+@Service
+@RequiredArgsConstructor
+public class FirebasePhotoService implements PhotoService {
+
+    private final static String INVALID_PHOTO_PROVIDED_MESSAGE = "Invalid photo provided";
+    private final static String MISSING_FILE_EXTENSION = "Missing file extension";
+    private final static String PHOTO = "Photo";
+    private static final Set<String> acceptedImageTypes = Set.of(
+            "image/jpeg",
+            "image/jpg",
+            "image/png",
+            "image/webp"
+    );
+
+    @Value("${firebase.photo.directory}")
+    private String PHOTO_DIRECTORY;
+
+    @Value("${firebase.photo.expiration.max-seconds}")
+    private Integer MAX_EXPIRATION_SECONDS;
+
+    @Value("${firebase.photo.expiration.threshold-seconds}")
+    private Integer EXPIRATION_THRESHOLD_SECONDS;
+
+    private final FirebaseApp firebaseApp;
+    private final CloudPhotoRepository cloudPhotoRepository;
+    private final Tika tika;
+
+
+    @Override
+    public CloudPhoto getPhoto(String blob) {
+        return cloudPhotoRepository.findById(blob)
+                .orElseThrow(() -> NotFoundException.withFormattedMessage(PHOTO, blob));
+    }
+
+    @Override
+    public CloudPhoto uploadPhoto(MultipartFile multipartFile) {
+        validatePhoto(multipartFile);
+        CloudPhoto photo = uploadFile(multipartFile, MAX_EXPIRATION_SECONDS);
+        return cloudPhotoRepository.save(photo);
+    }
+
+    @Override
+    public void deletePhoto(String blob) {
+        CloudPhoto photo = getPhoto(blob);
+        StorageClient storageClient = StorageClient.getInstance(firebaseApp);
+        Bucket bucket = storageClient.bucket();
+        Blob blobToDelete = bucket.get(blob);
+
+        if(blobToDelete != null) {
+            blobToDelete.delete();
+        }
+
+        cloudPhotoRepository.delete(photo);
+    }
+
+    @Override
+    public CloudPhoto updatePhotoExpiration(CloudPhoto photo) {
+        LocalDateTime thresholdTime = photo
+                .getUrlExpiresAt()
+                .minusSeconds(EXPIRATION_THRESHOLD_SECONDS);
+
+        if(thresholdTime.isAfter(LocalDateTime.now())) {
+            return photo;
+        }
+
+        return renewPhoto(photo, MAX_EXPIRATION_SECONDS);
+    }
+
+    /**
+     * Checks if the provided file is not empty and if its type matches the accepted types defined in the acceptedImageTypes set.
+     * */
+     private void validatePhoto(MultipartFile multipartFile) {
+         if (multipartFile == null || multipartFile.isEmpty()) {
+             throw new InvalidPhotoException(INVALID_PHOTO_PROVIDED_MESSAGE);
+         }
+
+         try(InputStream inputStream = multipartFile.getInputStream()) {
+             String mimeType = tika.detect(inputStream);
+
+             if(!acceptedImageTypes.contains(mimeType)) {
+                 throw InvalidPhotoException.invalidType(mimeType, acceptedImageTypes);
+             }
+
+         } catch (IOException e) {
+             throw new InvalidPhotoException(INVALID_PHOTO_PROVIDED_MESSAGE);
+         }
+     }
+
+    /**
+     * @return Extension of the file like .jpg, .png, .jpeg
+     * */
+    private String getExtension(String fileName) {
+        if(fileName == null) {
+            throw new InvalidPhotoException(MISSING_FILE_EXTENSION);
+        }
+
+        return fileName.substring(fileName.lastIndexOf("."));
+    }
+
+    private CloudPhoto uploadFile(MultipartFile file, int expirationSeconds) {
+        StorageClient storageClient = StorageClient.getInstance(firebaseApp);
+        Bucket bucket = storageClient.bucket();
+        String filename = UUID.randomUUID() + getExtension(file.getOriginalFilename());
+        String blobPath = PHOTO_DIRECTORY + "/" + filename;
+
+        try {
+            Blob blob = bucket.create(blobPath, file.getInputStream(), file.getContentType());
+            String url = blob.signUrl(expirationSeconds, TimeUnit.SECONDS).toString();
+
+            return CloudPhoto.builder()
+                    .url(url)
+                    .blob(blobPath)
+                    .urlExpiresAt(LocalDateTime.now().plusSeconds(expirationSeconds))
+                    .build();
+        } catch(IOException e) {
+            throw new InvalidPhotoException(INVALID_PHOTO_PROVIDED_MESSAGE);
+        }
+    }
+
+    private CloudPhoto renewPhoto(CloudPhoto photo, int expirationSeconds) {
+        StorageClient storageClient = StorageClient.getInstance(firebaseApp);
+        Bucket bucket = storageClient.bucket();
+        Blob blob = bucket.get(photo.getBlob());
+
+        if(blob == null) {
+            throw NotFoundException.withFormattedMessage(PHOTO, photo.getBlob());
+        }
+
+        String newUrl = blob.signUrl(expirationSeconds, TimeUnit.SECONDS).toString();
+        photo.setUrl(newUrl);
+        photo.setUrlExpiresAt(LocalDateTime.now().plusSeconds(expirationSeconds));
+        return cloudPhotoRepository.save(photo);
+    }
+}

--- a/src/main/java/com/example/petbuddybackend/service/image/PhotoService.java
+++ b/src/main/java/com/example/petbuddybackend/service/image/PhotoService.java
@@ -1,0 +1,15 @@
+package com.example.petbuddybackend.service.image;
+
+import com.example.petbuddybackend.entity.photo.CloudPhoto;
+import org.springframework.web.multipart.MultipartFile;
+
+public interface PhotoService {
+
+    CloudPhoto uploadPhoto(MultipartFile multipartFile);
+
+    void deletePhoto(String blob);
+
+    CloudPhoto updatePhotoExpiration(CloudPhoto photo);
+
+    CloudPhoto getPhoto(String blob);
+}

--- a/src/main/java/com/example/petbuddybackend/service/image/PhotoService.java
+++ b/src/main/java/com/example/petbuddybackend/service/image/PhotoService.java
@@ -1,15 +1,15 @@
 package com.example.petbuddybackend.service.image;
 
-import com.example.petbuddybackend.entity.photo.CloudPhoto;
+import com.example.petbuddybackend.entity.photo.PhotoLink;
 import org.springframework.web.multipart.MultipartFile;
 
 public interface PhotoService {
 
-    CloudPhoto uploadPhoto(MultipartFile multipartFile);
+    PhotoLink uploadPhoto(MultipartFile multipartFile);
 
     void deletePhoto(String blob);
 
-    CloudPhoto updatePhotoExpiration(CloudPhoto photo);
+    PhotoLink updatePhotoExpiration(PhotoLink photo);
 
-    CloudPhoto getPhoto(String blob);
+    PhotoLink getPhoto(String blob);
 }

--- a/src/main/java/com/example/petbuddybackend/utils/exception/advice/GeneralAdvice.java
+++ b/src/main/java/com/example/petbuddybackend/utils/exception/advice/GeneralAdvice.java
@@ -25,6 +25,7 @@ import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.ResponseStatus;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 import org.springframework.web.method.annotation.HandlerMethodValidationException;
+import org.springframework.web.multipart.MaxUploadSizeExceededException;
 
 import java.time.DateTimeException;
 import java.time.zone.ZoneRulesException;
@@ -156,9 +157,15 @@ public class GeneralAdvice {
         return new ApiExceptionResponse(e, e.getMessage());
     }
 
-    @ResponseStatus(code = HttpStatus.BAD_REQUEST)
     @ExceptionHandler(InvalidPhotoException.class)
+    @ResponseStatus(code = HttpStatus.BAD_REQUEST)
     public ApiExceptionResponse handleGeneralException(InvalidPhotoException e) {
         return new ApiExceptionResponse(e, e.getMessage());
+    }
+
+    @ExceptionHandler(MaxUploadSizeExceededException.class)
+    @ResponseStatus(code = HttpStatus.PAYLOAD_TOO_LARGE)
+    public ApiExceptionResponse handleMaxUploadSizeExceededException(MaxUploadSizeExceededException e) {
+        return new ApiExceptionResponse(e, "Maximum file upload size exceeded");
     }
 }

--- a/src/main/java/com/example/petbuddybackend/utils/exception/advice/GeneralAdvice.java
+++ b/src/main/java/com/example/petbuddybackend/utils/exception/advice/GeneralAdvice.java
@@ -2,6 +2,7 @@ package com.example.petbuddybackend.utils.exception.advice;
 
 import com.example.petbuddybackend.utils.exception.throweable.general.DateRangeException;
 import com.example.petbuddybackend.utils.exception.throweable.general.UnauthorizedException;
+import com.example.petbuddybackend.utils.exception.throweable.photo.InvalidPhotoException;
 import com.example.petbuddybackend.utils.exception.throweable.websocket.InvalidWebSocketHeaderException;
 import com.example.petbuddybackend.utils.exception.throweable.websocket.MissingWebSocketHeaderException;
 import com.example.petbuddybackend.utils.exception.throweable.chat.ChatAlreadyExistsException;
@@ -155,4 +156,9 @@ public class GeneralAdvice {
         return new ApiExceptionResponse(e, e.getMessage());
     }
 
+    @ResponseStatus(code = HttpStatus.BAD_REQUEST)
+    @ExceptionHandler(InvalidPhotoException.class)
+    public ApiExceptionResponse handleGeneralException(InvalidPhotoException e) {
+        return new ApiExceptionResponse(e, e.getMessage());
+    }
 }

--- a/src/main/java/com/example/petbuddybackend/utils/exception/throweable/photo/InvalidPhotoException.java
+++ b/src/main/java/com/example/petbuddybackend/utils/exception/throweable/photo/InvalidPhotoException.java
@@ -1,0 +1,21 @@
+package com.example.petbuddybackend.utils.exception.throweable.photo;
+
+import java.util.Set;
+
+public class InvalidPhotoException extends RuntimeException {
+
+    private static final String INVALID_FILE_TYPE_MESSAGE =
+            "Invalid file type. Provided: %s, allowed: %s";
+
+    public InvalidPhotoException(String message) {
+        super(message);
+    }
+
+    public static InvalidPhotoException invalidType(String extension, Set<String> allowedExtensions) {
+        String extensions = allowedExtensions.stream()
+                .reduce((a, b) -> a + ", " + b)
+                .orElse("");
+
+        return new InvalidPhotoException(String.format(INVALID_FILE_TYPE_MESSAGE, extension, extensions));
+    }
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -18,6 +18,10 @@ spring:
     show-sql: false
   profiles:
     active: dev
+  servlet:
+    multipart:
+      max-file-size: 50MB
+      max-request-size: 50MB
 
   # import data for database
   config:
@@ -60,3 +64,16 @@ url:
     topic:
       base: "/topic/session"
       pattern: "/topic/session/%s"
+
+firebase:
+  key:
+    path: secret/petbuddy-firebase-private-key.json
+  project:
+    id: petbuddy-d6479
+  bucket:
+    link: petbuddy-d6479.appspot.com
+  photo:
+    directory: ${FIREBASE_PHOTO_DIRECTORY}
+    expiration:
+      max-seconds: 21600        # 6 hours
+      threshold-seconds: 2300   # 0.5 hour

--- a/src/test/java/com/example/petbuddybackend/controller/ChatWebSocketIntegrationTest.java
+++ b/src/test/java/com/example/petbuddybackend/controller/ChatWebSocketIntegrationTest.java
@@ -102,7 +102,7 @@ public class ChatWebSocketIntegrationTest {
         ChatMessageSent chatMessageSent = new ChatMessageSent("hello");
         StompSession stompSession = connectToWebSocket();
 
-        when(chatService.isUserInChat(any(), any()))
+        when(chatService.isUserInChat(any(Long.class), any(String.class), any(Role.class)))
                 .thenReturn(true);
 
         // Init session
@@ -125,7 +125,7 @@ public class ChatWebSocketIntegrationTest {
         String caretakerTimezone = "+06:00";
         ChatMessageSent chatMessageSent = new ChatMessageSent("hello");
 
-        when(chatService.isUserInChat(any(), any()))
+        when(chatService.isUserInChat(any(Long.class), any(String.class), any(Role.class)))
                 .thenReturn(true);
 
         StompSession clientSession = connectToWebSocket(clientUsername);
@@ -169,7 +169,7 @@ public class ChatWebSocketIntegrationTest {
         String clientUsername = "client";
         String caretakerUsername = "caretaker";
 
-        when(chatService.isUserInChat(any(), any()))
+        when(chatService.isUserInChat(any(Long.class), any(String.class), any(Role.class)))
                 .thenReturn(true);
 
         StompSession clientSession = connectToWebSocket(clientUsername);
@@ -202,11 +202,11 @@ public class ChatWebSocketIntegrationTest {
     }
 
     @Test
-    void testUnsubscribeToChat_shouldSendNotificationToOtherUserLeftInChat() throws InterruptedException {
+    void testDisconnectFromChat_shouldSendNotificationToOtherUserLeftInChat() throws InterruptedException {
         String clientUsername = "client";
         String caretakerUsername = "caretaker";
 
-        when(chatService.isUserInChat(any(), any()))
+        when(chatService.isUserInChat(any(Long.class), any(String.class), any(Role.class)))
                 .thenReturn(true);
 
         StompSession clientSession = connectToWebSocket(clientUsername);
@@ -236,7 +236,7 @@ public class ChatWebSocketIntegrationTest {
         String clientUsername = "client";
         String caretakerUsername = "caretaker";
 
-        when(chatService.isUserInChat(any(), any()))
+        when(chatService.isUserInChat(any(Long.class), any(String.class), any(Role.class)))
                 .thenReturn(true);
 
         StompSession clientSession = connectToWebSocket(clientUsername);

--- a/src/test/java/com/example/petbuddybackend/service/offer/OfferServiceIntegrationTest.java
+++ b/src/test/java/com/example/petbuddybackend/service/offer/OfferServiceIntegrationTest.java
@@ -5,7 +5,7 @@ import com.example.petbuddybackend.dto.availability.AvailabilityRangeDTO;
 import com.example.petbuddybackend.dto.availability.CreateOffersAvailabilityDTO;
 import com.example.petbuddybackend.dto.offer.ModifyConfigurationDTO;
 import com.example.petbuddybackend.dto.offer.ModifyOfferDTO;
-import com.example.petbuddybackend.repository.AvailabilityRepository;
+import com.example.petbuddybackend.repository.availability.AvailabilityRepository;
 import com.example.petbuddybackend.testconfig.TestDataConfiguration;
 import com.example.petbuddybackend.dto.animal.AnimalDTO;
 import com.example.petbuddybackend.dto.offer.OfferConfigurationDTO;

--- a/src/test/java/com/example/petbuddybackend/service/photo/PhotoServiceTest.java
+++ b/src/test/java/com/example/petbuddybackend/service/photo/PhotoServiceTest.java
@@ -1,0 +1,163 @@
+package com.example.petbuddybackend.service.photo;
+
+import com.example.petbuddybackend.entity.photo.CloudPhoto;
+import com.example.petbuddybackend.repository.photo.CloudPhotoRepository;
+import com.example.petbuddybackend.service.image.FirebasePhotoService;
+import com.example.petbuddybackend.utils.exception.throweable.general.NotFoundException;
+import com.example.petbuddybackend.utils.exception.throweable.photo.InvalidPhotoException;
+import com.google.cloud.storage.Blob;
+import com.google.cloud.storage.Bucket;
+import com.google.firebase.FirebaseApp;
+import com.google.firebase.cloud.StorageClient;
+import org.apache.tika.Tika;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mock;
+import org.mockito.MockedStatic;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.mock.web.MockMultipartFile;
+
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.net.MalformedURLException;
+import java.net.URL;
+import java.time.LocalDateTime;
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.*;
+
+@SpringBootTest
+public class PhotoServiceTest {
+
+    private static final String FILE_NAME = "test.jpg";
+    private static final String BLOB_PATH = "valid/blob/path";
+    private static final String PHOTO_URL = "http://signedurl.com";
+
+    @Value("${firebase.photo.directory}")
+    private String PHOTO_DIRECTORY;
+
+    @Autowired
+    private FirebasePhotoService firebasePhotoService;
+
+    @MockBean
+    private FirebaseApp firebaseApp;
+
+    @MockBean
+    private CloudPhotoRepository cloudPhotoRepository;
+
+    @MockBean
+    private Tika tika;
+
+    @Mock
+    private Blob mockBlob;
+
+    @Mock
+    private StorageClient mockStorageClient;
+
+    @Mock
+    private Bucket mockBucket;
+
+    private MockedStatic<StorageClient> storageClientMock;
+    private MockMultipartFile validPhoto;
+
+    @BeforeEach
+    public void setUp() {
+        validPhoto = new MockMultipartFile(
+                "file",
+                FILE_NAME,
+                "image/jpeg",
+                new byte[]{0, 1, 2}
+        );
+
+        storageClientMock = mockStatic(StorageClient.class);
+
+        when(StorageClient.getInstance(firebaseApp)).thenReturn(mockStorageClient);
+        when(mockStorageClient.bucket()).thenReturn(mockBucket);
+    }
+
+    @AfterEach
+    public void tearDown() {
+        storageClientMock.close();
+    }
+
+
+    @Test
+    public void testUploadPhoto_validFile_shouldUploadSuccessfully() throws IOException {
+        // Arrange
+        when(mockBucket.create(any(String.class), any(ByteArrayInputStream.class), any(String.class))).thenReturn(mockBlob);
+        when(mockBlob.signUrl(anyLong(), any())).thenReturn(new URL("http://signedurl.com"));
+        when(tika.detect(any(InputStream.class))).thenReturn("image/jpeg");
+        when(cloudPhotoRepository.save(any(CloudPhoto.class))).thenAnswer(invocation -> invocation.getArgument(0));
+
+        // Act
+        CloudPhoto result = firebasePhotoService.uploadPhoto(validPhoto);
+
+        // Assert
+        assertNotNull(result);
+        assertNotEquals(PHOTO_DIRECTORY + "/" + FILE_NAME, result.getBlob());
+        assertTrue(result.getBlob().startsWith(PHOTO_DIRECTORY));
+        verify(cloudPhotoRepository, times(1)).save(result);
+    }
+
+    @Test
+    public void testUploadPhoto_invalidFile_shouldThrowInvalidPhotoException() throws IOException {
+        // Arrange
+        MockMultipartFile invalidPhoto = new MockMultipartFile("file", "", "text/plain", new byte[]{0});
+        when(tika.detect(any(InputStream.class))).thenReturn("text/plain");
+
+        // Act & Assert
+        assertThrows(InvalidPhotoException.class, () -> {
+            firebasePhotoService.uploadPhoto(invalidPhoto);
+        });
+    }
+
+    @Test
+    public void testDeletePhoto_validBlob_shouldDeleteSuccessfully() {
+        CloudPhoto photo = new CloudPhoto(BLOB_PATH, PHOTO_URL, LocalDateTime.now().plusDays(10));
+        when(cloudPhotoRepository.findById(BLOB_PATH)).thenReturn(Optional.of(photo));
+        when(mockBucket.get(BLOB_PATH)).thenReturn(mockBlob);
+
+        firebasePhotoService.deletePhoto(BLOB_PATH);
+
+        verify(mockBlob, times(1)).delete();
+        verify(cloudPhotoRepository, times(1)).delete(photo);
+    }
+
+    @Test
+    public void testDeletePhoto_nonExistentBlob_shouldNotThrowException() {
+        String nonExistentBlob = "non/existent/blob";
+
+        when(cloudPhotoRepository.findById(nonExistentBlob)).thenReturn(Optional.empty());
+
+        assertThrows(NotFoundException.class, () -> firebasePhotoService.deletePhoto(nonExistentBlob));
+    }
+
+    @Test
+    public void testUpdatePhotoExpiration_withinThreshold_shouldNotRenew() {
+        LocalDateTime expiresAt = LocalDateTime.now().plusDays(20);
+        CloudPhoto photo = new CloudPhoto("valid/blob/path", "http://signedurl.com", expiresAt);
+
+        firebasePhotoService.updatePhotoExpiration(photo);
+
+        verify(cloudPhotoRepository, never()).save(any());
+    }
+
+    @Test
+    public void testUpdatePhotoExpiration_expired_shouldRenew() throws MalformedURLException {
+        LocalDateTime expiresAt = LocalDateTime.now().minusSeconds(1);
+        CloudPhoto photo = new CloudPhoto("valid/blob/path", "http://signedurl.com", expiresAt);
+        when(mockBucket.get(photo.getBlob())).thenReturn(mockBlob);
+        when(mockBlob.signUrl(anyLong(), any())).thenReturn(new URL("http://new-signedurl.com"));
+
+        firebasePhotoService.updatePhotoExpiration(photo);
+
+        verify(cloudPhotoRepository, times(1)).save(photo);
+    }
+}

--- a/src/test/java/com/example/petbuddybackend/service/photo/PhotoServiceTest.java
+++ b/src/test/java/com/example/petbuddybackend/service/photo/PhotoServiceTest.java
@@ -90,16 +90,13 @@ public class PhotoServiceTest {
 
     @Test
     public void testUploadPhoto_validFile_shouldUploadSuccessfully() throws IOException {
-        // Arrange
         when(mockBucket.create(any(String.class), any(ByteArrayInputStream.class), any(String.class))).thenReturn(mockBlob);
         when(mockBlob.signUrl(anyLong(), any())).thenReturn(new URL("http://signedurl.com"));
         when(tika.detect(any(InputStream.class))).thenReturn("image/jpeg");
         when(cloudPhotoRepository.save(any(CloudPhoto.class))).thenAnswer(invocation -> invocation.getArgument(0));
 
-        // Act
         CloudPhoto result = firebasePhotoService.uploadPhoto(validPhoto);
 
-        // Assert
         assertNotNull(result);
         assertNotEquals(PHOTO_DIRECTORY + "/" + FILE_NAME, result.getBlob());
         assertTrue(result.getBlob().startsWith(PHOTO_DIRECTORY));
@@ -108,11 +105,9 @@ public class PhotoServiceTest {
 
     @Test
     public void testUploadPhoto_invalidFile_shouldThrowInvalidPhotoException() throws IOException {
-        // Arrange
         MockMultipartFile invalidPhoto = new MockMultipartFile("file", "", "text/plain", new byte[]{0});
         when(tika.detect(any(InputStream.class))).thenReturn("text/plain");
 
-        // Act & Assert
         assertThrows(InvalidPhotoException.class, () -> {
             firebasePhotoService.uploadPhoto(invalidPhoto);
         });

--- a/src/test/java/com/example/petbuddybackend/testconfig/FirebaseMockBean.java
+++ b/src/test/java/com/example/petbuddybackend/testconfig/FirebaseMockBean.java
@@ -1,0 +1,16 @@
+package com.example.petbuddybackend.testconfig;
+
+import com.google.firebase.FirebaseApp;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+import static org.mockito.Mockito.mock;
+
+@Configuration
+public class FirebaseMockBean {
+
+    @Bean
+    public FirebaseApp firebaseAppMock() {
+        return mock(FirebaseApp.class);
+    }
+}

--- a/src/test/java/com/example/petbuddybackend/testconfig/NoSecurityInjectUserConfig.java
+++ b/src/test/java/com/example/petbuddybackend/testconfig/NoSecurityInjectUserConfig.java
@@ -1,5 +1,6 @@
 package com.example.petbuddybackend.testconfig;
 
+import com.example.petbuddybackend.config.security.BodyAndQueryTokenResolver;
 import jakarta.servlet.FilterChain;
 import jakarta.servlet.ServletException;
 import jakarta.servlet.ServletRequest;
@@ -7,12 +8,19 @@ import jakarta.servlet.ServletResponse;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Profile;
+import org.springframework.core.Ordered;
+import org.springframework.core.annotation.Order;
+import org.springframework.messaging.Message;
+import org.springframework.messaging.support.ChannelInterceptor;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.authorization.AuthorizationManager;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.security.core.userdetails.User;
+import org.springframework.security.messaging.access.intercept.MessageMatcherDelegatingAuthorizationManager;
+import org.springframework.security.oauth2.server.resource.web.BearerTokenResolver;
 import org.springframework.security.web.SecurityFilterChain;
 import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
 
@@ -39,7 +47,7 @@ public class NoSecurityInjectUserConfig {
         return http.build();
     }
 
-    final static class TestAuthenticationFilter extends UsernamePasswordAuthenticationFilter {
+    private final static class TestAuthenticationFilter extends UsernamePasswordAuthenticationFilter {
 
         @Override
         public void doFilter(ServletRequest request, ServletResponse response, FilterChain chain) throws IOException, ServletException {
@@ -54,5 +62,30 @@ public class NoSecurityInjectUserConfig {
                     Collections.emptyList()
             );
         }
+    }
+
+    @Bean
+    public MessageMatcherDelegatingAuthorizationManager.Builder messageMatcherBuilder() {
+        return new MessageMatcherDelegatingAuthorizationManager.Builder();
+    }
+
+    @Bean
+    public AuthorizationManager<Message<?>> messageAuthorizationManager(MessageMatcherDelegatingAuthorizationManager.Builder messages) {
+        return messages
+                .anyMessage().permitAll()
+                .build();
+    }
+
+    @Bean
+    public BearerTokenResolver bearerTokenResolver() {
+        return new BodyAndQueryTokenResolver();
+    }
+
+    @Order(Ordered.HIGHEST_PRECEDENCE)
+    @Bean("csrfChannelInterceptor")
+    public ChannelInterceptor noopCsrfInterceptor() {
+        // Disables CSRF protection for WebSocket messages
+        return new ChannelInterceptor() {
+        };
     }
 }

--- a/src/test/resources/application.yml
+++ b/src/test/resources/application.yml
@@ -45,3 +45,17 @@ url:
     topic:
       base: "/topic/session"
       pattern: "/topic/session/%s"
+
+
+firebase:
+  key:
+    path: path
+  project:
+    id: none
+  bucket:
+    link: none
+  photo:
+    directory: none
+    expiration:
+      max-seconds: 21600
+      threshold-seconds: 2300


### PR DESCRIPTION
## Dodano
- integracja z Firebase Storage i upload zdjęć
- naprawienie testów websocket'ów
- automatycznie usuwanie zdjęć z chmury dla profilu `dev` backendu w celu oszczędzania miejsca w chmurze

## Zmienne potrzebne w backendzie
Dojdzie plik `{root}/secret/petbuddy-firebase-private-key.json` i zmienna `FIREBASE_PHOTO_DIRECTORY` do dodania, żeby móc odpalić API

Plik jest potrzebny w celu autoryzacji z Firebase. Dodałem jeszcze "furtkę", żeby mozna było ten plik załadować ze zmiennych środowiskowych. Ostatnio jak korzystałem z Firebase takie rozwiązanie przydało się przy deployu aplikacji, więc uznałem że to zostawię.

Zmienna `FIREBASE_PHOTO_DIRECTORY` jest potrzebna do określenia folderu, do którego będą dodawane/usuwane zdjęcia. Dzięki temu, każdy będzie mógł ustawić tam swoją nazwę i wszyscy odpalający api na swojej maszynie nie będą sobie nawzajem usuwać zdjęć.