### PR TITLE
Cyndzer/ZPI-37-ZPI-21-BE-18-BE-45-Profile-pictures-upload

### DIFF
--- a/src/main/java/com/example/petbuddybackend/controller/ClientController.java
+++ b/src/main/java/com/example/petbuddybackend/controller/ClientController.java
@@ -17,7 +17,7 @@ import java.security.Principal;
 
 @RestController
 @RequiredArgsConstructor
-@RequestMapping("/client")
+@RequestMapping("/api/client")
 public class ClientController {
 
     private final ClientService clientService;

--- a/src/main/java/com/example/petbuddybackend/controller/UserController.java
+++ b/src/main/java/com/example/petbuddybackend/controller/UserController.java
@@ -1,6 +1,7 @@
 package com.example.petbuddybackend.controller;
 
 import com.example.petbuddybackend.dto.photo.PhotoLinkDTO;
+import com.example.petbuddybackend.dto.user.ProfileData;
 import com.example.petbuddybackend.dto.user.UserProfiles;
 import com.example.petbuddybackend.service.user.UserService;
 import io.swagger.v3.oas.annotations.Operation;
@@ -13,7 +14,7 @@ import java.security.Principal;
 
 @RestController
 @RequiredArgsConstructor
-@RequestMapping("/user")
+@RequestMapping("/api/user")
 public class UserController {
 
     private final UserService userService;
@@ -25,15 +26,28 @@ public class UserController {
         return userService.getUserProfiles(principal.getName());
     }
 
+    @GetMapping
+    @Operation(
+            summary = "Get user profile data",
+            description = "Returns profile data associated with the principal."
+    )
+    @PreAuthorize("isAuthenticated()")
+    public ProfileData getUserProfileData(Principal principal) {
+        return userService.getProfileData(principal.getName());
+    }
+
     @PostMapping("/profile-picture")
     @Operation(
             summary = "Upload profile picture",
-            description = "Uploads profile picture that is shared between all user profiles"
+            description = """
+                Uploads profile picture that is shared between all user profiles.
+                If user already has a profile picture, it will be replaced.
+                """
     )
     @PreAuthorize("isAuthenticated()")
     public PhotoLinkDTO uploadProfilePicture(
             Principal principal,
-            MultipartFile profilePicture
+            @RequestParam MultipartFile profilePicture
     ) {
         return userService.uploadProfilePicture(principal.getName(), profilePicture);
     }
@@ -41,7 +55,7 @@ public class UserController {
     @DeleteMapping("/profile-picture")
     @Operation(
             summary = "Delete profile picture",
-            description = "Deletes profile picture that is shared between all user profiles"
+            description = "Deletes profile picture. All user profiles will be affected."
     )
     @PreAuthorize("isAuthenticated()")
     public void deleteProfilePicture(Principal principal) {

--- a/src/main/java/com/example/petbuddybackend/controller/UserController.java
+++ b/src/main/java/com/example/petbuddybackend/controller/UserController.java
@@ -6,6 +6,7 @@ import com.example.petbuddybackend.dto.user.UserProfiles;
 import com.example.petbuddybackend.service.user.UserService;
 import io.swagger.v3.oas.annotations.Operation;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.MediaType;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.web.bind.annotation.*;
 import org.springframework.web.multipart.MultipartFile;
@@ -36,7 +37,7 @@ public class UserController {
         return userService.getProfileData(principal.getName());
     }
 
-    @PostMapping("/profile-picture")
+    @PostMapping( value = "/profile-picture", consumes = { MediaType.MULTIPART_FORM_DATA_VALUE })
     @Operation(
             summary = "Upload profile picture",
             description = """
@@ -47,7 +48,7 @@ public class UserController {
     @PreAuthorize("isAuthenticated()")
     public PhotoLinkDTO uploadProfilePicture(
             Principal principal,
-            @RequestParam MultipartFile profilePicture
+            @RequestPart MultipartFile profilePicture
     ) {
         return userService.uploadProfilePicture(principal.getName(), profilePicture);
     }

--- a/src/main/java/com/example/petbuddybackend/controller/UserController.java
+++ b/src/main/java/com/example/petbuddybackend/controller/UserController.java
@@ -1,13 +1,13 @@
 package com.example.petbuddybackend.controller;
 
+import com.example.petbuddybackend.dto.photo.PhotoLinkDTO;
 import com.example.petbuddybackend.dto.user.UserProfiles;
 import com.example.petbuddybackend.service.user.UserService;
 import io.swagger.v3.oas.annotations.Operation;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.access.prepost.PreAuthorize;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
+import org.springframework.web.multipart.MultipartFile;
 
 import java.security.Principal;
 
@@ -25,4 +25,26 @@ public class UserController {
         return userService.getUserProfiles(principal.getName());
     }
 
+    @PostMapping("/profile-picture")
+    @Operation(
+            summary = "Upload profile picture",
+            description = "Uploads profile picture that is shared between all user profiles"
+    )
+    @PreAuthorize("isAuthenticated()")
+    public PhotoLinkDTO uploadProfilePicture(
+            Principal principal,
+            MultipartFile profilePicture
+    ) {
+        return userService.uploadProfilePicture(principal.getName(), profilePicture);
+    }
+
+    @DeleteMapping("/profile-picture")
+    @Operation(
+            summary = "Delete profile picture",
+            description = "Deletes profile picture that is shared between all user profiles"
+    )
+    @PreAuthorize("isAuthenticated()")
+    public void deleteProfilePicture(Principal principal) {
+        userService.deleteProfilePicture(principal.getName());
+    }
 }

--- a/src/main/java/com/example/petbuddybackend/dto/photo/PhotoLinkDTO.java
+++ b/src/main/java/com/example/petbuddybackend/dto/photo/PhotoLinkDTO.java
@@ -1,0 +1,10 @@
+package com.example.petbuddybackend.dto.photo;
+
+import lombok.Builder;
+
+@Builder
+public record PhotoLinkDTO(
+        String blob,
+        String url
+) {
+}

--- a/src/main/java/com/example/petbuddybackend/dto/user/AccountDataDTO.java
+++ b/src/main/java/com/example/petbuddybackend/dto/user/AccountDataDTO.java
@@ -1,11 +1,13 @@
 package com.example.petbuddybackend.dto.user;
 
+import com.example.petbuddybackend.dto.photo.PhotoLinkDTO;
 import lombok.Builder;
 
 @Builder
 public record AccountDataDTO(
         String email,
         String name,
-        String surname
+        String surname,
+        PhotoLinkDTO profilePicture
 ) {
 }

--- a/src/main/java/com/example/petbuddybackend/dto/user/ProfileData.java
+++ b/src/main/java/com/example/petbuddybackend/dto/user/ProfileData.java
@@ -1,0 +1,11 @@
+package com.example.petbuddybackend.dto.user;
+
+import lombok.Builder;
+
+@Builder
+public record ProfileData(
+        AccountDataDTO accountData,
+        Boolean hasClientProfile,
+        Boolean hasCaretakerProfile
+) {
+}

--- a/src/main/java/com/example/petbuddybackend/entity/user/AppUser.java
+++ b/src/main/java/com/example/petbuddybackend/entity/user/AppUser.java
@@ -1,5 +1,6 @@
 package com.example.petbuddybackend.entity.user;
 
+import com.example.petbuddybackend.entity.photo.PhotoLink;
 import jakarta.persistence.*;
 import lombok.*;
 
@@ -21,11 +22,14 @@ public class AppUser {
     @Column(nullable = false, length = 100)
     private String surname;
 
+    @OneToOne(cascade = CascadeType.REMOVE, fetch = FetchType.LAZY)
+    private PhotoLink profilePicture;
+
     @JoinColumn(name = "email")
-    @OneToOne(mappedBy = "accountData", cascade = CascadeType.REMOVE, fetch = FetchType.LAZY)
+    @OneToOne(cascade = CascadeType.REMOVE, fetch = FetchType.LAZY)
     private Caretaker caretaker;
 
     @JoinColumn(name = "email")
-    @OneToOne(mappedBy = "accountData", cascade = CascadeType.REMOVE, fetch = FetchType.LAZY)
+    @OneToOne(cascade = CascadeType.REMOVE, fetch = FetchType.LAZY)
     private Client client;
 }

--- a/src/main/java/com/example/petbuddybackend/entity/user/Caretaker.java
+++ b/src/main/java/com/example/petbuddybackend/entity/user/Caretaker.java
@@ -28,7 +28,7 @@ public class Caretaker {
     private String description;
 
     @PrimaryKeyJoinColumn
-    @OneToOne(cascade = CascadeType.MERGE, optional = false)
+    @OneToOne(mappedBy = "caretaker", cascade = CascadeType.MERGE, optional = false)
     private AppUser accountData;
 
     @Basic(fetch = FetchType.LAZY)

--- a/src/main/java/com/example/petbuddybackend/entity/user/Client.java
+++ b/src/main/java/com/example/petbuddybackend/entity/user/Client.java
@@ -19,7 +19,7 @@ public class Client {
     private String email;
 
     @PrimaryKeyJoinColumn
-    @OneToOne(cascade = CascadeType.MERGE, optional = false)
+    @OneToOne(mappedBy = "client", cascade = CascadeType.MERGE, optional = false)
     private AppUser accountData;
 
     @OneToMany(cascade = CascadeType.ALL, mappedBy = "client", fetch = FetchType.LAZY)

--- a/src/main/java/com/example/petbuddybackend/service/mapper/PhotoMapper.java
+++ b/src/main/java/com/example/petbuddybackend/service/mapper/PhotoMapper.java
@@ -1,0 +1,14 @@
+package com.example.petbuddybackend.service.mapper;
+
+import com.example.petbuddybackend.dto.photo.PhotoLinkDTO;
+import com.example.petbuddybackend.entity.photo.PhotoLink;
+import org.mapstruct.Mapper;
+import org.mapstruct.factory.Mappers;
+
+@Mapper
+public interface PhotoMapper {
+
+    PhotoMapper INSTANCE = Mappers.getMapper(PhotoMapper.class);
+
+    PhotoLinkDTO mapToPhotoLinkDTO(PhotoLink photoLink);
+}

--- a/src/main/java/com/example/petbuddybackend/service/mapper/UserMapper.java
+++ b/src/main/java/com/example/petbuddybackend/service/mapper/UserMapper.java
@@ -3,6 +3,7 @@ package com.example.petbuddybackend.service.mapper;
 import com.example.petbuddybackend.dto.user.ProfileData;
 import com.example.petbuddybackend.entity.user.AppUser;
 import org.mapstruct.Mapper;
+import org.mapstruct.Mapping;
 import org.mapstruct.factory.Mappers;
 
 @Mapper
@@ -10,5 +11,6 @@ public interface UserMapper {
 
     UserMapper INSTANCE = Mappers.getMapper(UserMapper.class);
 
+    @Mapping(source = "user", target = "accountData")
     ProfileData mapToProfileData(AppUser user, Boolean hasClientProfile, Boolean hasCaretakerProfile);
 }

--- a/src/main/java/com/example/petbuddybackend/service/mapper/UserMapper.java
+++ b/src/main/java/com/example/petbuddybackend/service/mapper/UserMapper.java
@@ -1,0 +1,14 @@
+package com.example.petbuddybackend.service.mapper;
+
+import com.example.petbuddybackend.dto.user.ProfileData;
+import com.example.petbuddybackend.entity.user.AppUser;
+import org.mapstruct.Mapper;
+import org.mapstruct.factory.Mappers;
+
+@Mapper
+public interface UserMapper {
+
+    UserMapper INSTANCE = Mappers.getMapper(UserMapper.class);
+
+    ProfileData mapToProfileData(AppUser user, Boolean hasClientProfile, Boolean hasCaretakerProfile);
+}

--- a/src/main/java/com/example/petbuddybackend/service/photo/FirebasePhotoService.java
+++ b/src/main/java/com/example/petbuddybackend/service/photo/FirebasePhotoService.java
@@ -12,6 +12,7 @@ import lombok.RequiredArgsConstructor;
 import org.apache.tika.Tika;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.multipart.MultipartFile;
 
 import java.io.IOException;
@@ -65,8 +66,16 @@ public class FirebasePhotoService implements PhotoService {
     }
 
     @Override
+    @Transactional
     public void deletePhoto(String blob) {
         PhotoLink photo = getPhoto(blob);
+        deletePhoto(photo);
+    }
+
+    @Override
+    @Transactional
+    public void deletePhoto(PhotoLink photoLink) {
+        String blob = photoLink.getBlob();
         StorageClient storageClient = StorageClient.getInstance(firebaseApp);
         Bucket bucket = storageClient.bucket();
         Blob blobToDelete = bucket.get(blob);
@@ -75,7 +84,7 @@ public class FirebasePhotoService implements PhotoService {
             blobToDelete.delete();
         }
 
-        photoRepository.delete(photo);
+        photoRepository.delete(photoLink);
     }
 
     @Override

--- a/src/main/java/com/example/petbuddybackend/service/photo/FirebasePhotoService.java
+++ b/src/main/java/com/example/petbuddybackend/service/photo/FirebasePhotoService.java
@@ -1,4 +1,4 @@
-package com.example.petbuddybackend.service.image;
+package com.example.petbuddybackend.service.photo;
 
 import com.example.petbuddybackend.entity.photo.PhotoLink;
 import com.example.petbuddybackend.repository.photo.PhotoLinkRepository;

--- a/src/main/java/com/example/petbuddybackend/service/photo/PhotoService.java
+++ b/src/main/java/com/example/petbuddybackend/service/photo/PhotoService.java
@@ -1,4 +1,4 @@
-package com.example.petbuddybackend.service.image;
+package com.example.petbuddybackend.service.photo;
 
 import com.example.petbuddybackend.entity.photo.PhotoLink;
 import org.springframework.web.multipart.MultipartFile;

--- a/src/main/java/com/example/petbuddybackend/service/photo/PhotoService.java
+++ b/src/main/java/com/example/petbuddybackend/service/photo/PhotoService.java
@@ -9,6 +9,8 @@ public interface PhotoService {
 
     void deletePhoto(String blob);
 
+    void deletePhoto(PhotoLink photoLink);
+
     PhotoLink updatePhotoExpiration(PhotoLink photo);
 
     PhotoLink getPhoto(String blob);

--- a/src/main/java/com/example/petbuddybackend/service/user/UserService.java
+++ b/src/main/java/com/example/petbuddybackend/service/user/UserService.java
@@ -1,12 +1,14 @@
 package com.example.petbuddybackend.service.user;
 
 import com.example.petbuddybackend.dto.photo.PhotoLinkDTO;
+import com.example.petbuddybackend.dto.user.ProfileData;
 import com.example.petbuddybackend.dto.user.UserProfiles;
 import com.example.petbuddybackend.entity.photo.PhotoLink;
 import com.example.petbuddybackend.entity.user.AppUser;
 import com.example.petbuddybackend.repository.user.AppUserRepository;
 import com.example.petbuddybackend.repository.user.CaretakerRepository;
 import com.example.petbuddybackend.repository.user.ClientRepository;
+import com.example.petbuddybackend.service.mapper.UserMapper;
 import com.example.petbuddybackend.service.photo.PhotoService;
 import com.example.petbuddybackend.service.mapper.PhotoMapper;
 import com.example.petbuddybackend.utils.exception.throweable.general.NotFoundException;
@@ -29,6 +31,7 @@ public class UserService {
     private final CaretakerRepository caretakerRepository;
     private final PhotoService photoService;
     private final PhotoMapper photoMapper = PhotoMapper.INSTANCE;
+    private final UserMapper userMapper = UserMapper.INSTANCE;
 
     @Transactional
     public AppUser createUserIfNotExistOrGet(JwtAuthenticationToken token) {
@@ -65,6 +68,15 @@ public class UserService {
                 .hasClientProfile(clientRepository.existsById(email))
                 .hasCaretakerProfile(caretakerRepository.existsById(email))
                 .build();
+    }
+
+    public ProfileData getProfileData(String email) {
+        AppUser user = getAppUser(email);
+        return userMapper.mapToProfileData(
+                user,
+                clientRepository.existsById(email),
+                caretakerRepository.existsById(email)
+        );
     }
 
     @Transactional

--- a/src/main/java/com/example/petbuddybackend/service/user/UserService.java
+++ b/src/main/java/com/example/petbuddybackend/service/user/UserService.java
@@ -82,6 +82,12 @@ public class UserService {
     @Transactional
     public PhotoLinkDTO uploadProfilePicture(String username, MultipartFile profilePicture) {
         AppUser user = getAppUser(username);
+        PhotoLink oldPhoto = user.getProfilePicture();
+
+        if(oldPhoto != null) {
+            photoService.deletePhoto(oldPhoto);
+        }
+
         PhotoLink photoLink = photoService.uploadPhoto(profilePicture);
 
         user.setProfilePicture(photoLink);

--- a/src/main/java/com/example/petbuddybackend/utils/exception/advice/CustomExceptionAdvice.java
+++ b/src/main/java/com/example/petbuddybackend/utils/exception/advice/CustomExceptionAdvice.java
@@ -1,0 +1,86 @@
+package com.example.petbuddybackend.utils.exception.advice;
+
+import com.example.petbuddybackend.utils.exception.ApiExceptionResponse;
+import com.example.petbuddybackend.utils.exception.throweable.chat.ChatAlreadyExistsException;
+import com.example.petbuddybackend.utils.exception.throweable.chat.InvalidMessageReceiverException;
+import com.example.petbuddybackend.utils.exception.throweable.chat.NotParticipateException;
+import com.example.petbuddybackend.utils.exception.throweable.general.DateRangeException;
+import com.example.petbuddybackend.utils.exception.throweable.general.IllegalActionException;
+import com.example.petbuddybackend.utils.exception.throweable.general.NotFoundException;
+import com.example.petbuddybackend.utils.exception.throweable.general.UnauthorizedException;
+import com.example.petbuddybackend.utils.exception.throweable.photo.InvalidPhotoException;
+import com.example.petbuddybackend.utils.exception.throweable.websocket.InvalidWebSocketHeaderException;
+import com.example.petbuddybackend.utils.exception.throweable.websocket.MissingWebSocketHeaderException;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.core.Ordered;
+import org.springframework.core.annotation.Order;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.ResponseStatus;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+@Slf4j
+@RestControllerAdvice
+@Order(Ordered.HIGHEST_PRECEDENCE)
+public class CustomExceptionAdvice {
+
+    @ExceptionHandler(NotFoundException.class)
+    @ResponseStatus(code = HttpStatus.NOT_FOUND)
+    public ApiExceptionResponse handleNotFoundException(NotFoundException e) {
+        return new ApiExceptionResponse(e, e.getMessage());
+    }
+
+    @ExceptionHandler(IllegalActionException.class)
+    @ResponseStatus(code = HttpStatus.BAD_REQUEST)
+    public ApiExceptionResponse handleIllegalActionException(IllegalActionException e) {
+        return new ApiExceptionResponse(e, e.getMessage());
+    }
+
+    @ExceptionHandler(NotParticipateException.class)
+    @ResponseStatus(code = HttpStatus.FORBIDDEN)
+    public ApiExceptionResponse handleNotParticipantException(NotParticipateException e) {
+        return new ApiExceptionResponse(e, e.getMessage());
+    }
+
+    @ExceptionHandler(ChatAlreadyExistsException.class)
+    @ResponseStatus(code = HttpStatus.CONFLICT)
+    public ApiExceptionResponse handleResourceAlreadyExists(ChatAlreadyExistsException e) {
+        return new ApiExceptionResponse(e, e.getMessage());
+    }
+
+    @ExceptionHandler(InvalidMessageReceiverException.class)
+    @ResponseStatus(code = HttpStatus.BAD_REQUEST)
+    public ApiExceptionResponse handleInvalidMessageReceiverException(InvalidMessageReceiverException e) {
+        return new ApiExceptionResponse(e, e.getMessage());
+    }
+
+    @ExceptionHandler(MissingWebSocketHeaderException.class)
+    @ResponseStatus(code = HttpStatus.BAD_REQUEST)
+    public ApiExceptionResponse handleMissingWebSocketHeaderException(MissingWebSocketHeaderException e) {
+        return new ApiExceptionResponse(e, e.getMessage());
+    }
+
+    @ExceptionHandler(InvalidWebSocketHeaderException.class)
+    @ResponseStatus(code = HttpStatus.BAD_REQUEST)
+    public ApiExceptionResponse handleInvalidWebSocketHeaderException(InvalidWebSocketHeaderException e) {
+        return new ApiExceptionResponse(e, e.getMessage());
+    }
+
+    @ExceptionHandler(InvalidPhotoException.class)
+    @ResponseStatus(code = HttpStatus.BAD_REQUEST)
+    public ApiExceptionResponse handleGeneralException(InvalidPhotoException e) {
+        return new ApiExceptionResponse(e, e.getMessage());
+    }
+
+    @ExceptionHandler(DateRangeException.class)
+    @ResponseStatus(code = HttpStatus.BAD_REQUEST)
+    public ApiExceptionResponse handleDateRangeException(DateRangeException e) {
+        return new ApiExceptionResponse(e, e.getMessage());
+    }
+
+    @ExceptionHandler(UnauthorizedException.class)
+    @ResponseStatus(code = HttpStatus.UNAUTHORIZED)
+    public ApiExceptionResponse handleUnauthorizedException(UnauthorizedException e) {
+        return new ApiExceptionResponse(e, e.getMessage());
+    }
+}

--- a/src/main/java/com/example/petbuddybackend/utils/exception/advice/GeneralAdvice.java
+++ b/src/main/java/com/example/petbuddybackend/utils/exception/advice/GeneralAdvice.java
@@ -1,16 +1,6 @@
 package com.example.petbuddybackend.utils.exception.advice;
 
-import com.example.petbuddybackend.utils.exception.throweable.general.DateRangeException;
-import com.example.petbuddybackend.utils.exception.throweable.general.UnauthorizedException;
-import com.example.petbuddybackend.utils.exception.throweable.photo.InvalidPhotoException;
-import com.example.petbuddybackend.utils.exception.throweable.websocket.InvalidWebSocketHeaderException;
-import com.example.petbuddybackend.utils.exception.throweable.websocket.MissingWebSocketHeaderException;
-import com.example.petbuddybackend.utils.exception.throweable.chat.ChatAlreadyExistsException;
 import com.example.petbuddybackend.utils.exception.ApiExceptionResponse;
-import com.example.petbuddybackend.utils.exception.throweable.chat.InvalidMessageReceiverException;
-import com.example.petbuddybackend.utils.exception.throweable.general.IllegalActionException;
-import com.example.petbuddybackend.utils.exception.throweable.general.NotFoundException;
-import com.example.petbuddybackend.utils.exception.throweable.chat.NotParticipateException;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.core.Ordered;
 import org.springframework.core.annotation.Order;

--- a/src/main/java/com/example/petbuddybackend/utils/exception/advice/GeneralAdvice.java
+++ b/src/main/java/com/example/petbuddybackend/utils/exception/advice/GeneralAdvice.java
@@ -70,27 +70,9 @@ public class GeneralAdvice {
         return new ApiExceptionResponse(e, errorList.toString());
     }
 
-    @ExceptionHandler(NotFoundException.class)
-    @ResponseStatus(code = HttpStatus.NOT_FOUND)
-    public ApiExceptionResponse handleNotFoundException(NotFoundException e) {
-        return new ApiExceptionResponse(e, e.getMessage());
-    }
-
-    @ExceptionHandler(IllegalActionException.class)
-    @ResponseStatus(code = HttpStatus.BAD_REQUEST)
-    public ApiExceptionResponse handleIllegalActionException(IllegalActionException e) {
-        return new ApiExceptionResponse(e, e.getMessage());
-    }
-
     @ExceptionHandler(PropertyReferenceException.class)
     @ResponseStatus(code = HttpStatus.BAD_REQUEST)
     public ApiExceptionResponse handlePropertyReferenceException(PropertyReferenceException e) {
-        return new ApiExceptionResponse(e, e.getMessage());
-    }
-
-    @ExceptionHandler(NotParticipateException.class)
-    @ResponseStatus(code = HttpStatus.FORBIDDEN)
-    public ApiExceptionResponse handleNotParticipantException(NotParticipateException e) {
         return new ApiExceptionResponse(e, e.getMessage());
     }
 
@@ -103,12 +85,6 @@ public class GeneralAdvice {
     @ExceptionHandler(DateTimeException.class)
     @ResponseStatus(code = HttpStatus.BAD_REQUEST)
     public ApiExceptionResponse handleDateTimeException(DateTimeException e) {
-        return new ApiExceptionResponse(e, e.getMessage());
-    }
-
-    @ExceptionHandler(ChatAlreadyExistsException.class)
-    @ResponseStatus(code = HttpStatus.CONFLICT)
-    public ApiExceptionResponse handleResourceAlreadyExists(ChatAlreadyExistsException e) {
         return new ApiExceptionResponse(e, e.getMessage());
     }
 
@@ -127,42 +103,6 @@ public class GeneralAdvice {
     @ExceptionHandler(MethodArgumentTypeMismatchException.class)
     @ResponseStatus(code = HttpStatus.BAD_REQUEST)
     public ApiExceptionResponse handleMethodArgumentTypeMismatchException(MethodArgumentTypeMismatchException e) {
-        return new ApiExceptionResponse(e, e.getMessage());
-    }
-
-    @ExceptionHandler(InvalidMessageReceiverException.class)
-    @ResponseStatus(code = HttpStatus.BAD_REQUEST)
-    public ApiExceptionResponse handleInvalidMessageReceiverException(InvalidMessageReceiverException e) {
-        return new ApiExceptionResponse(e, e.getMessage());
-    }
-
-    @ExceptionHandler(MissingWebSocketHeaderException.class)
-    @ResponseStatus(code = HttpStatus.BAD_REQUEST)
-    public ApiExceptionResponse handleMissingWebSocketHeaderException(MissingWebSocketHeaderException e) {
-        return new ApiExceptionResponse(e, e.getMessage());
-    }
-
-    @ExceptionHandler(InvalidWebSocketHeaderException.class)
-    @ResponseStatus(code = HttpStatus.BAD_REQUEST)
-    public ApiExceptionResponse handleInvalidWebSocketHeaderException(InvalidWebSocketHeaderException e) {
-        return new ApiExceptionResponse(e, e.getMessage());
-    }
-
-    @ExceptionHandler(UnauthorizedException.class)
-    @ResponseStatus(code = HttpStatus.UNAUTHORIZED)
-    public ApiExceptionResponse handleUnauthorizedException(UnauthorizedException e) {
-        return new ApiExceptionResponse(e, e.getMessage());
-    }
-
-    @ExceptionHandler(DateRangeException.class)
-    @ResponseStatus(code = HttpStatus.BAD_REQUEST)
-    public ApiExceptionResponse handleDateRangeException(DateRangeException e) {
-        return new ApiExceptionResponse(e, e.getMessage());
-    }
-
-    @ExceptionHandler(InvalidPhotoException.class)
-    @ResponseStatus(code = HttpStatus.BAD_REQUEST)
-    public ApiExceptionResponse handleGeneralException(InvalidPhotoException e) {
         return new ApiExceptionResponse(e, e.getMessage());
     }
 

--- a/src/main/java/com/example/petbuddybackend/utils/exception/advice/GeneralAdvice.java
+++ b/src/main/java/com/example/petbuddybackend/utils/exception/advice/GeneralAdvice.java
@@ -18,6 +18,7 @@ import org.springframework.data.mapping.PropertyReferenceException;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.converter.HttpMessageNotReadableException;
 import org.springframework.messaging.handler.annotation.support.MethodArgumentTypeMismatchException;
+import org.springframework.security.authorization.AuthorizationDeniedException;
 import org.springframework.validation.FieldError;
 import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.MissingRequestHeaderException;
@@ -26,6 +27,8 @@ import org.springframework.web.bind.annotation.ResponseStatus;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 import org.springframework.web.method.annotation.HandlerMethodValidationException;
 import org.springframework.web.multipart.MaxUploadSizeExceededException;
+import org.springframework.web.multipart.support.MissingServletRequestPartException;
+import org.springframework.web.servlet.NoHandlerFoundException;
 
 import java.time.DateTimeException;
 import java.time.zone.ZoneRulesException;
@@ -167,5 +170,22 @@ public class GeneralAdvice {
     @ResponseStatus(code = HttpStatus.PAYLOAD_TOO_LARGE)
     public ApiExceptionResponse handleMaxUploadSizeExceededException(MaxUploadSizeExceededException e) {
         return new ApiExceptionResponse(e, "Maximum file upload size exceeded");
+    }
+
+    @ExceptionHandler(AuthorizationDeniedException.class)
+    @ResponseStatus(code = HttpStatus.FORBIDDEN)
+    public void handleAuthorizationDeniedException(AuthorizationDeniedException e) {
+    }
+
+    @ExceptionHandler(NoHandlerFoundException.class)
+    @ResponseStatus(code = HttpStatus.BAD_REQUEST)
+    public ApiExceptionResponse handleNoHandlerFoundException(NoHandlerFoundException e) {
+        return new ApiExceptionResponse(e, e.getMessage());
+    }
+
+    @ExceptionHandler(MissingServletRequestPartException.class)
+    @ResponseStatus(code = HttpStatus.BAD_REQUEST)
+    public ApiExceptionResponse handleMissingServletRequestPartException(MissingServletRequestPartException e) {
+        return new ApiExceptionResponse(e, e.getMessage());
     }
 }

--- a/src/test/java/com/example/petbuddybackend/controller/ClientControllerTest.java
+++ b/src/test/java/com/example/petbuddybackend/controller/ClientControllerTest.java
@@ -42,7 +42,7 @@ public class ClientControllerTest {
                 .build()
         );
 
-        mockMvc.perform(get("/client")
+        mockMvc.perform(get("/api/client")
                         .header(roleHeaderName, Role.CLIENT))
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.accountData.email").value("clientEmail"));

--- a/src/test/java/com/example/petbuddybackend/controller/UserControllerTest.java
+++ b/src/test/java/com/example/petbuddybackend/controller/UserControllerTest.java
@@ -1,7 +1,11 @@
 package com.example.petbuddybackend.controller;
 
+import com.example.petbuddybackend.dto.photo.PhotoLinkDTO;
+import com.example.petbuddybackend.dto.user.AccountDataDTO;
+import com.example.petbuddybackend.dto.user.ProfileData;
 import com.example.petbuddybackend.dto.user.UserProfiles;
 import com.example.petbuddybackend.service.user.UserService;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.MockitoAnnotations;
@@ -9,10 +13,16 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.mock.web.MockMultipartFile;
 import org.springframework.security.test.context.support.WithMockUser;
 import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.web.multipart.MultipartFile;
 
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.when;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.user;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
@@ -21,38 +31,106 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 @AutoConfigureMockMvc
 public class UserControllerTest {
 
+    public static final String USERNAME = "testuser";
     @Autowired
     private MockMvc mockMvc;
 
     @MockBean
     private UserService userService;
 
+    private AutoCloseable closeable;
+
     @BeforeEach
     void setUp() {
-        MockitoAnnotations.openMocks(this);
+        closeable = MockitoAnnotations.openMocks(this);
+    }
+
+    @AfterEach
+    void tearDown() throws Exception {
+        closeable.close();
     }
 
     @Test
-    @WithMockUser(username = "testuser")
+    @WithMockUser(USERNAME)
     void getAvailableUserProfiles_shouldReturnAvailableUserProfiles() throws Exception {
-        // given
-        String username = "testuser";
-
         // when
-        when(userService.getUserProfiles(username)).thenReturn(
+        when(userService.getUserProfiles(USERNAME)).thenReturn(
                 UserProfiles.builder()
-                        .email(username)
+                        .email(USERNAME)
                         .hasClientProfile(true)
                         .hasCaretakerProfile(true)
                         .build()
         );
 
         // then
-        mockMvc.perform(get("/user/available-profiles"))
+        mockMvc.perform(get("/api/user/available-profiles"))
                 .andExpect(status().isOk())
-                .andExpect(jsonPath("$.email").value(username))
+                .andExpect(jsonPath("$.email").value(USERNAME))
                 .andExpect(jsonPath("$.hasClientProfile").value(true))
                 .andExpect(jsonPath("$.hasCaretakerProfile").value(true));
     }
 
+    @Test
+    @WithMockUser(USERNAME)
+    void getUserProfiles_shouldReturnUserProfiles() throws Exception {
+        // given
+        String name = "user name";
+        String surname = "user surname";
+        AccountDataDTO accountData = new AccountDataDTO(USERNAME, name, surname, null);
+        ProfileData profileData = new ProfileData(accountData, true, false);
+
+        // when
+        when(userService.getProfileData(USERNAME)).thenReturn(profileData);
+
+        // then
+        mockMvc.perform(get("/api/user")
+                        .with(user(USERNAME)))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.accountData.email").value(USERNAME))
+                .andExpect(jsonPath("$.accountData.name").value(name))
+                .andExpect(jsonPath("$.accountData.surname").value(surname))
+                .andExpect(jsonPath("$.hasClientProfile").value(true))
+                .andExpect(jsonPath("$.hasCaretakerProfile").value(false));
+    }
+
+    @Test
+    @WithMockUser(USERNAME)
+    void uploadProfilePicture_shouldReturnPhotoLinkDTO() throws Exception {
+        // given
+        String url = "http://example.com/profile.jpg";
+        String blob = "someBlob";
+        MockMultipartFile mockFile = new MockMultipartFile("profilePicture", "profile.jpg", "image/jpeg", "test image".getBytes());
+        PhotoLinkDTO photoLinkDTO = new PhotoLinkDTO(blob, url);
+
+        // when
+        when(userService.uploadProfilePicture(eq(USERNAME), any(MultipartFile.class))).thenReturn(photoLinkDTO);
+
+        // then
+        mockMvc.perform(multipart("/api/user/profile-picture")
+                        .file(mockFile)
+                        .with(user(USERNAME)))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.url").value(url))
+                .andExpect(jsonPath("$.blob").value(blob));
+    }
+
+    @Test
+    @WithMockUser(USERNAME)
+    void uploadProfilePicture_noPictureProvided_shouldReturn400() throws Exception {
+        // then
+        mockMvc.perform(multipart("/api/user/profile-picture")
+                        .with(user(USERNAME)))
+                .andExpect(status().isBadRequest());
+    }
+
+    @Test
+    @WithMockUser(USERNAME)
+    void deleteProfilePicture_shouldReturnNoContent() throws Exception {
+        // when & then
+        doNothing().when(userService).deleteProfilePicture(USERNAME);
+
+        mockMvc.perform(delete("/api/user/profile-picture")
+                        .with(user(USERNAME)))
+                .andExpect(status().isOk());
+    }
 }

--- a/src/test/java/com/example/petbuddybackend/service/mapper/PhotoMapperTest.java
+++ b/src/test/java/com/example/petbuddybackend/service/mapper/PhotoMapperTest.java
@@ -1,0 +1,20 @@
+package com.example.petbuddybackend.service.mapper;
+
+import com.example.petbuddybackend.entity.photo.PhotoLink;
+import com.example.petbuddybackend.testutils.ValidationUtils;
+import com.example.petbuddybackend.testutils.mock.MockUserProvider;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+public class PhotoMapperTest {
+
+    private final PhotoMapper mapper = PhotoMapper.INSTANCE;
+
+    @Test
+    void mapToPhotoLinkDTO_shouldNotLeaveNullFields() {
+        PhotoLink photoLink = MockUserProvider.createMockPhotoLink();
+
+        assertTrue(ValidationUtils.fieldsNotNullRecursive(mapper.mapToPhotoLinkDTO(photoLink)));
+    }
+}

--- a/src/test/java/com/example/petbuddybackend/service/mapper/UserMapperTest.java
+++ b/src/test/java/com/example/petbuddybackend/service/mapper/UserMapperTest.java
@@ -1,0 +1,22 @@
+package com.example.petbuddybackend.service.mapper;
+
+import com.example.petbuddybackend.dto.user.ProfileData;
+import com.example.petbuddybackend.entity.user.AppUser;
+import com.example.petbuddybackend.testutils.ValidationUtils;
+import com.example.petbuddybackend.testutils.mock.MockUserProvider;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+public class UserMapperTest {
+
+    private final UserMapper mapper = UserMapper.INSTANCE;
+
+    @Test
+    void mapToProfileData_shouldNotLeaveNullFields() {
+        AppUser user = MockUserProvider.createMockAppUser(MockUserProvider.createMockPhotoLink());
+
+        ProfileData profileData = mapper.mapToProfileData(user, true, true);
+        assertTrue(ValidationUtils.fieldsNotNullRecursive(profileData));
+    }
+}

--- a/src/test/java/com/example/petbuddybackend/service/photo/PhotoServiceTest.java
+++ b/src/test/java/com/example/petbuddybackend/service/photo/PhotoServiceTest.java
@@ -2,7 +2,6 @@ package com.example.petbuddybackend.service.photo;
 
 import com.example.petbuddybackend.entity.photo.PhotoLink;
 import com.example.petbuddybackend.repository.photo.PhotoLinkRepository;
-import com.example.petbuddybackend.service.image.FirebasePhotoService;
 import com.example.petbuddybackend.utils.exception.throweable.general.NotFoundException;
 import com.example.petbuddybackend.utils.exception.throweable.photo.InvalidPhotoException;
 import com.google.cloud.storage.Blob;

--- a/src/test/java/com/example/petbuddybackend/testutils/PersistenceUtils.java
+++ b/src/test/java/com/example/petbuddybackend/testutils/PersistenceUtils.java
@@ -43,6 +43,10 @@ public class PersistenceUtils {
         return appUserRepository.save(appUser);
     }
 
+    public static AppUser addAppUser(AppUserRepository appUserRepository, AppUser appUser) {
+        return appUserRepository.saveAndFlush(appUser);
+    }
+
     public static List<Caretaker> addCaretakers(CaretakerRepository caretakerRepository, AppUserRepository appUserRepository, List<Caretaker> caretakers) {
         List<AppUser> accountData = caretakers.stream()
                 .map(Caretaker::getAccountData)
@@ -100,10 +104,6 @@ public class PersistenceUtils {
     public static Client addClient(AppUserRepository appUserRepository, ClientRepository clientRepository) {
         Client client = createMockClient();
         return addClient(appUserRepository, clientRepository, client);
-    }
-
-    public static AppUser addAppUser(AppUserRepository appUserRepository, AppUser appUser) {
-        return appUserRepository.saveAndFlush(appUser);
     }
 
     public static Offer addComplexOffer(Caretaker caretaker,

--- a/src/test/java/com/example/petbuddybackend/testutils/ValidationUtils.java
+++ b/src/test/java/com/example/petbuddybackend/testutils/ValidationUtils.java
@@ -1,13 +1,18 @@
 package com.example.petbuddybackend.testutils;
 
+import lombok.NoArgsConstructor;
 import lombok.SneakyThrows;
-
+import lombok.extern.slf4j.Slf4j;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import java.lang.reflect.Field;
 import java.util.Set;
 
+@Slf4j
+@NoArgsConstructor(access = lombok.AccessLevel.PRIVATE)
 public final class ValidationUtils {
 
-    private ValidationUtils() {}
+    private static final Logger logger = LoggerFactory.getLogger(ValidationUtils.class);
 
     @SneakyThrows
     public static boolean fieldsNotNullRecursive(Object obj, Set<String> fieldsToSkip) {
@@ -19,8 +24,9 @@ public final class ValidationUtils {
 
             if (field.get(obj) == null && !fieldsToSkip.contains(field.getName())) {
                 allNotNull = false;
-                System.out.println("Field '" + field.getName() + "' is null in object: " + obj.getClass().getSimpleName());
+                logger.error("Field '{}' is null in object: {}", field.getName(), obj.getClass().getSimpleName());
             } else if (ReflectionUtils.isClass(field)) {
+                logger.info("Descending into '{}' field that is a class", field.getName());
                 allNotNull = fieldsNotNullRecursive(field.get(obj));
             }
         }

--- a/src/test/java/com/example/petbuddybackend/testutils/mock/MockUserProvider.java
+++ b/src/test/java/com/example/petbuddybackend/testutils/mock/MockUserProvider.java
@@ -2,6 +2,7 @@ package com.example.petbuddybackend.testutils.mock;
 
 import com.example.petbuddybackend.entity.address.Address;
 import com.example.petbuddybackend.entity.address.Voivodeship;
+import com.example.petbuddybackend.entity.photo.PhotoLink;
 import com.example.petbuddybackend.entity.user.AppUser;
 import com.example.petbuddybackend.entity.user.Caretaker;
 import com.example.petbuddybackend.entity.user.Client;
@@ -28,11 +29,7 @@ public final class MockUserProvider {
     }
 
     public static Caretaker createMockCaretaker(String name, String surname, String email, Address address) {
-        AppUser accountData = AppUser.builder()
-                .email(email)
-                .name(name)
-                .surname(surname)
-                .build();
+        AppUser accountData = createMockAppUser(name, surname, email);
 
         return Caretaker.builder()
                 .email(email)
@@ -69,13 +66,11 @@ public final class MockUserProvider {
     }
 
     public static Client createMockClient(String newClientEmail) {
+        AppUser accountData = createMockAppUser("clientName", "clientSurname", newClientEmail);
+
         return Client.builder()
                 .email(newClientEmail)
-                .accountData(AppUser.builder()
-                        .email(newClientEmail)
-                        .name("clientName")
-                        .surname("clientSurname")
-                        .build())
+                .accountData(accountData)
                 .build();
     }
 
@@ -84,11 +79,7 @@ public final class MockUserProvider {
     }
 
     public static Client createMockClient(String name, String surname, String email) {
-        AppUser accountData = AppUser.builder()
-                .email(email)
-                .name(name)
-                .surname(surname)
-                .build();
+        AppUser accountData = createMockAppUser(name, surname, email);
 
         return Client.builder()
                 .email(email)
@@ -96,13 +87,28 @@ public final class MockUserProvider {
                 .build();
     }
 
-    public static AppUser createMockAppUser() {
-
+    public static AppUser createMockAppUser(String name, String surname, String email) {
         return AppUser.builder()
-                .name("Imie")
-                .surname("Nazwisko")
-                .email("email")
+                .name(name)
+                .surname(surname)
+                .email(email)
                 .build();
+    }
 
+    public static AppUser createMockAppUser() {
+        return createMockAppUser("name", "surname", "email");
+    }
+
+    public static AppUser createMockAppUser(PhotoLink photoLink) {
+        AppUser user = createMockAppUser("appUser_name", "appUser_surname", "appUser_email");
+        user.setProfilePicture(photoLink);
+        return user;
+    }
+
+    public static PhotoLink createMockPhotoLink() {
+        return PhotoLink.builder()
+                .blob("blobexample")
+                .url("http://example.com")
+                .build();
     }
 }


### PR DESCRIPTION
- dodanie możliwości do uploadu i usunięcia zdjęcia profilowego
- GET `/api/user` danych konta użytkownika. Zrobiłem to z uwzględnieniem informacji z istniejącego `/api/user/available-profiles`, więc można się zastanowić czy nowy endpoint nie zastąpi starego
- refactor RestControllerAdvice na plik GeneralAdvice z wyjątkami pochodzącymi z bibliotek, oraz CustomExceptionAdvice z wyjątkami stworzonymi w tym projekcie
- drobny refactor