### PR TITLE
Gawron/ZPI-14-ZPI-59-BE-59-Wyszukanie-obserwowanych-opiekunów

### DIFF
--- a/src/main/java/com/example/petbuddybackend/controller/ClientController.java
+++ b/src/main/java/com/example/petbuddybackend/controller/ClientController.java
@@ -1,6 +1,6 @@
 package com.example.petbuddybackend.controller;
 
-import com.example.petbuddybackend.dto.user.CaretakerDTO;
+import com.example.petbuddybackend.dto.user.AccountDataDTO;
 import com.example.petbuddybackend.dto.user.ClientDTO;
 import com.example.petbuddybackend.entity.user.Role;
 import com.example.petbuddybackend.service.user.ClientService;
@@ -57,11 +57,11 @@ public class ClientController {
     }
 
     @Operation(summary = "Get followed caretakers of client")
-    @GetMapping("/followed-caretakers")
+    @GetMapping("/follow")
     @PreAuthorize("isAuthenticated()")
-    public Set<CaretakerDTO> getFollowedCaretakers(Principal principal,
+    public Set<AccountDataDTO> getFollowedCaretakers(Principal principal,
 
-                                                   @RoleParameter
+                                                     @RoleParameter
                                                    @AcceptRole(acceptRole = Role.CLIENT)
                                                    @RequestHeader(value = "${header-name.role}") Role role) {
 

--- a/src/main/java/com/example/petbuddybackend/controller/ClientController.java
+++ b/src/main/java/com/example/petbuddybackend/controller/ClientController.java
@@ -1,5 +1,6 @@
 package com.example.petbuddybackend.controller;
 
+import com.example.petbuddybackend.dto.user.CaretakerDTO;
 import com.example.petbuddybackend.dto.user.ClientDTO;
 import com.example.petbuddybackend.entity.user.Role;
 import com.example.petbuddybackend.service.user.ClientService;
@@ -35,11 +36,11 @@ public class ClientController {
     @PostMapping("/follow/{caretakerEmail}")
     @PreAuthorize("isAuthenticated()")
     public Set<String> addFollowingCaretakers(Principal principal,
+                                              @PathVariable String caretakerEmail,
 
-                                                       @PathVariable String caretakerEmail,
-                                                       @RoleParameter
-                                                       @AcceptRole(acceptRole = Role.CLIENT)
-                                                       @RequestHeader(value = "${header-name.role}") Role role) {
+                                              @RoleParameter
+                                              @AcceptRole(acceptRole = Role.CLIENT)
+                                              @RequestHeader(value = "${header-name.role}") Role role) {
         return clientService.addFollowingCaretaker(principal.getName(), caretakerEmail);
     }
 
@@ -50,9 +51,21 @@ public class ClientController {
                                                  @PathVariable String caretakerEmail,
 
                                                  @RoleParameter
-                                                          @AcceptRole(acceptRole = Role.CLIENT)
-                                                          @RequestHeader(value = "${header-name.role}") Role role) {
+                                                 @AcceptRole(acceptRole = Role.CLIENT)
+                                                 @RequestHeader(value = "${header-name.role}") Role role) {
         return clientService.removeFollowingCaretaker(principal.getName(), caretakerEmail);
+    }
+
+    @Operation(summary = "Get followed caretakers of client")
+    @GetMapping("/followed-caretakers")
+    @PreAuthorize("isAuthenticated()")
+    public Set<CaretakerDTO> getFollowedCaretakers(Principal principal,
+
+                                                   @RoleParameter
+                                                   @AcceptRole(acceptRole = Role.CLIENT)
+                                                   @RequestHeader(value = "${header-name.role}") Role role) {
+
+        return clientService.getFollowedCaretakers(principal.getName());
     }
 
 }

--- a/src/main/java/com/example/petbuddybackend/service/user/CaretakerService.java
+++ b/src/main/java/com/example/petbuddybackend/service/user/CaretakerService.java
@@ -13,6 +13,7 @@ import com.example.petbuddybackend.entity.user.AppUser;
 import com.example.petbuddybackend.entity.user.Caretaker;
 import com.example.petbuddybackend.repository.rating.RatingRepository;
 import com.example.petbuddybackend.repository.user.CaretakerRepository;
+import com.example.petbuddybackend.repository.user.ClientRepository;
 import com.example.petbuddybackend.service.mapper.CaretakerMapper;
 import com.example.petbuddybackend.service.mapper.RatingMapper;
 import com.example.petbuddybackend.utils.exception.throweable.general.IllegalActionException;
@@ -35,11 +36,11 @@ public class CaretakerService {
     private final static String CLIENT = "Client";
 
     private final CaretakerRepository caretakerRepository;
+    private final ClientRepository clientRepository;
     private final RatingRepository ratingRepository;
     private final CaretakerMapper caretakerMapper = CaretakerMapper.INSTANCE;
     private final RatingMapper ratingMapper = RatingMapper.INSTANCE;
 
-    private final ClientService clientService;
     private final UserService userService;
 
     @Transactional(readOnly = true)
@@ -144,7 +145,7 @@ public class CaretakerService {
             throw NotFoundException.withFormattedMessage(CARETAKER, caretakerEmail);
         }
 
-        if (!clientService.clientExists(clientEmail)) {
+        if (!clientRepository.existsById(clientEmail)) {
             throw NotFoundException.withFormattedMessage(CLIENT, clientEmail);
         }
     }

--- a/src/main/java/com/example/petbuddybackend/service/user/ClientService.java
+++ b/src/main/java/com/example/petbuddybackend/service/user/ClientService.java
@@ -35,10 +35,6 @@ public class ClientService {
     private final ClientMapper clientMapper = ClientMapper.INSTANCE;
     private final CaretakerMapper caretakerMapper = CaretakerMapper.INSTANCE;
 
-    public boolean clientExists(String clientEmail) {
-        return clientRepository.existsById(clientEmail);
-    }
-
     public Client getClientByEmail(String clientEmail) {
         return clientRepository.findById(clientEmail)
                 .orElseThrow(() -> NotFoundException.withFormattedMessage(CLIENT, clientEmail));
@@ -127,6 +123,10 @@ public class ClientService {
     private Caretaker getCaretakerByEmail(String caretakerEmail) {
         return caretakerRepository.findById(caretakerEmail)
                 .orElseThrow(() -> NotFoundException.withFormattedMessage(CARETAKER, caretakerEmail));
+    }
+
+    private boolean clientExists(String clientEmail) {
+        return clientRepository.existsById(clientEmail);
     }
 
     private Set<String> getFollowedCaretakersEmails(Client client) {

--- a/src/main/java/com/example/petbuddybackend/service/user/ClientService.java
+++ b/src/main/java/com/example/petbuddybackend/service/user/ClientService.java
@@ -1,14 +1,14 @@
 package com.example.petbuddybackend.service.user;
 
-import com.example.petbuddybackend.dto.user.CaretakerDTO;
+import com.example.petbuddybackend.dto.user.AccountDataDTO;
 import com.example.petbuddybackend.dto.user.ClientDTO;
 import com.example.petbuddybackend.entity.user.AppUser;
 import com.example.petbuddybackend.entity.user.Caretaker;
 import com.example.petbuddybackend.entity.user.Client;
 import com.example.petbuddybackend.repository.user.CaretakerRepository;
 import com.example.petbuddybackend.repository.user.ClientRepository;
-import com.example.petbuddybackend.service.mapper.CaretakerMapper;
 import com.example.petbuddybackend.service.mapper.ClientMapper;
+import com.example.petbuddybackend.service.mapper.UserMapper;
 import com.example.petbuddybackend.utils.exception.throweable.general.IllegalActionException;
 import com.example.petbuddybackend.utils.exception.throweable.general.NotFoundException;
 import lombok.RequiredArgsConstructor;
@@ -33,7 +33,7 @@ public class ClientService {
     private final CaretakerRepository caretakerRepository;
     private final UserService userService;
     private final ClientMapper clientMapper = ClientMapper.INSTANCE;
-    private final CaretakerMapper caretakerMapper = CaretakerMapper.INSTANCE;
+    private final UserMapper userMapper = UserMapper.INSTANCE;
 
     public Client getClientByEmail(String clientEmail) {
         return clientRepository.findById(clientEmail)
@@ -83,11 +83,12 @@ public class ClientService {
         return getFollowedCaretakersEmails(client);
     }
 
-    public Set<CaretakerDTO> getFollowedCaretakers(String clientEmail) {
+    public Set<AccountDataDTO> getFollowedCaretakers(String clientEmail) {
         Client client = getClientByEmail(clientEmail);
         return client.getFollowingCaretakers()
                 .stream()
-                .map(caretakerMapper::mapToCaretakerDTO)
+                .map(Caretaker::getAccountData)
+                .map(userMapper::mapToAccountDataDTO)
                 .collect(Collectors.toSet());
     }
 

--- a/src/main/java/com/example/petbuddybackend/service/user/ClientService.java
+++ b/src/main/java/com/example/petbuddybackend/service/user/ClientService.java
@@ -1,11 +1,13 @@
 package com.example.petbuddybackend.service.user;
 
+import com.example.petbuddybackend.dto.user.CaretakerDTO;
 import com.example.petbuddybackend.dto.user.ClientDTO;
 import com.example.petbuddybackend.entity.user.AppUser;
 import com.example.petbuddybackend.entity.user.Caretaker;
 import com.example.petbuddybackend.entity.user.Client;
 import com.example.petbuddybackend.repository.user.CaretakerRepository;
 import com.example.petbuddybackend.repository.user.ClientRepository;
+import com.example.petbuddybackend.service.mapper.CaretakerMapper;
 import com.example.petbuddybackend.service.mapper.ClientMapper;
 import com.example.petbuddybackend.utils.exception.throweable.general.IllegalActionException;
 import com.example.petbuddybackend.utils.exception.throweable.general.NotFoundException;
@@ -31,6 +33,7 @@ public class ClientService {
     private final CaretakerRepository caretakerRepository;
     private final UserService userService;
     private final ClientMapper clientMapper = ClientMapper.INSTANCE;
+    private final CaretakerMapper caretakerMapper = CaretakerMapper.INSTANCE;
 
     public boolean clientExists(String clientEmail) {
         return clientRepository.existsById(clientEmail);
@@ -84,6 +87,14 @@ public class ClientService {
         return getFollowedCaretakersEmails(client);
     }
 
+    public Set<CaretakerDTO> getFollowedCaretakers(String clientEmail) {
+        Client client = getClientByEmail(clientEmail);
+        return client.getFollowingCaretakers()
+                .stream()
+                .map(caretakerMapper::mapToCaretakerDTO)
+                .collect(Collectors.toSet());
+    }
+
     private Client createClient(JwtAuthenticationToken token) {
 
         AppUser appUser = userService.createUserIfNotExistOrGet(token);
@@ -124,5 +135,4 @@ public class ClientService {
                 .map(Caretaker::getEmail)
                 .collect(Collectors.toSet());
     }
-
 }

--- a/src/test/java/com/example/petbuddybackend/controller/ClientControllerTest.java
+++ b/src/test/java/com/example/petbuddybackend/controller/ClientControllerTest.java
@@ -1,7 +1,6 @@
 package com.example.petbuddybackend.controller;
 
 import com.example.petbuddybackend.dto.user.AccountDataDTO;
-import com.example.petbuddybackend.dto.user.CaretakerDTO;
 import com.example.petbuddybackend.dto.user.ClientDTO;
 import com.example.petbuddybackend.entity.user.Role;
 import com.example.petbuddybackend.service.user.ClientService;
@@ -15,12 +14,11 @@ import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.security.test.context.support.WithMockUser;
 import org.springframework.test.web.servlet.MockMvc;
 
-import java.util.List;
 import java.util.Set;
 
 import static org.mockito.Mockito.when;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 @SpringBootTest
@@ -122,33 +120,23 @@ public class ClientControllerTest {
     void getFollowedCaretakers_shouldReturnProperResponse() throws Exception {
 
         //Given
-        Set<CaretakerDTO> caretakers = Set.of(
-                CaretakerDTO.builder()
-                        .accountData(
-                                AccountDataDTO.builder()
-                                        .email("caretaker1@email")
-                                        .name("caretaker1")
-                                        .surname("caretaker1")
-                                        .build()
-                        )
-                        .animals(List.of("DOG"))
+        Set<AccountDataDTO> caretakers = Set.of(
+                AccountDataDTO.builder()
+                        .email("caretaker1@email")
+                        .name("caretaker1")
+                        .surname("caretaker1")
                         .build(),
-                CaretakerDTO.builder()
-                        .accountData(
-                                AccountDataDTO.builder()
-                                        .email("caretaker2@email")
-                                        .name("caretaker2")
-                                        .surname("caretaker2")
-                                        .build()
-                        )
-                        .animals(List.of("CAT"))
+                AccountDataDTO.builder()
+                        .email("caretaker2@email")
+                        .name("caretaker2")
+                        .surname("caretaker2")
                         .build()
         );
 
         when(clientService.getFollowedCaretakers("clientEmail")).thenReturn(caretakers);
 
         //When Then
-        mockMvc.perform(get("/api/client/followed-caretakers")
+        mockMvc.perform(get("/api/client/follow")
                         .header(roleHeaderName, Role.CLIENT))
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$").isArray());

--- a/src/test/java/com/example/petbuddybackend/controller/ClientControllerTest.java
+++ b/src/test/java/com/example/petbuddybackend/controller/ClientControllerTest.java
@@ -1,6 +1,7 @@
 package com.example.petbuddybackend.controller;
 
 import com.example.petbuddybackend.dto.user.AccountDataDTO;
+import com.example.petbuddybackend.dto.user.CaretakerDTO;
 import com.example.petbuddybackend.dto.user.ClientDTO;
 import com.example.petbuddybackend.entity.user.Role;
 import com.example.petbuddybackend.service.user.ClientService;
@@ -14,6 +15,7 @@ import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.security.test.context.support.WithMockUser;
 import org.springframework.test.web.servlet.MockMvc;
 
+import java.util.List;
 import java.util.Set;
 
 import static org.mockito.Mockito.when;
@@ -115,5 +117,43 @@ public class ClientControllerTest {
                 .andExpect(status().isBadRequest());
     }
 
+    @Test
+    @WithMockUser(username = "clientEmail")
+    void getFollowedCaretakers_shouldReturnProperResponse() throws Exception {
+
+        //Given
+        Set<CaretakerDTO> caretakers = Set.of(
+                CaretakerDTO.builder()
+                        .accountData(
+                                AccountDataDTO.builder()
+                                        .email("caretaker1@email")
+                                        .name("caretaker1")
+                                        .surname("caretaker1")
+                                        .build()
+                        )
+                        .animals(List.of("DOG"))
+                        .build(),
+                CaretakerDTO.builder()
+                        .accountData(
+                                AccountDataDTO.builder()
+                                        .email("caretaker2@email")
+                                        .name("caretaker2")
+                                        .surname("caretaker2")
+                                        .build()
+                        )
+                        .animals(List.of("CAT"))
+                        .build()
+        );
+
+        when(clientService.getFollowedCaretakers("clientEmail")).thenReturn(caretakers);
+
+        //When Then
+        mockMvc.perform(get("/api/client/followed-caretakers")
+                        .header(roleHeaderName, Role.CLIENT))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$").isArray())
+                .andExpect(jsonPath("$[0].accountData.email").value("caretaker1@email"));
+
+    }
 
 }

--- a/src/test/java/com/example/petbuddybackend/controller/ClientControllerTest.java
+++ b/src/test/java/com/example/petbuddybackend/controller/ClientControllerTest.java
@@ -151,8 +151,7 @@ public class ClientControllerTest {
         mockMvc.perform(get("/api/client/followed-caretakers")
                         .header(roleHeaderName, Role.CLIENT))
                 .andExpect(status().isOk())
-                .andExpect(jsonPath("$").isArray())
-                .andExpect(jsonPath("$[0].accountData.email").value("caretaker1@email"));
+                .andExpect(jsonPath("$").isArray());
 
     }
 

--- a/src/test/java/com/example/petbuddybackend/service/user/ClientServiceTest.java
+++ b/src/test/java/com/example/petbuddybackend/service/user/ClientServiceTest.java
@@ -1,6 +1,6 @@
 package com.example.petbuddybackend.service.user;
 
-import com.example.petbuddybackend.dto.user.CaretakerDTO;
+import com.example.petbuddybackend.dto.user.AccountDataDTO;
 import com.example.petbuddybackend.dto.user.ClientDTO;
 import com.example.petbuddybackend.entity.user.Caretaker;
 import com.example.petbuddybackend.entity.user.Client;
@@ -39,10 +39,6 @@ public class ClientServiceTest {
 
     @Autowired
     private ClientService clientService;
-
-    @Autowired
-    private UserService userService;
-
 
     @AfterEach
     void tearDown() {
@@ -213,7 +209,7 @@ public class ClientServiceTest {
         PersistenceUtils.addFollowingCaretakersToClient(clientRepository, client, new HashSet<>(caretakers));
 
         //When
-        Set<CaretakerDTO> result = clientService.getFollowedCaretakers(client.getEmail());
+        Set<AccountDataDTO> result = clientService.getFollowedCaretakers(client.getEmail());
 
         //Then
         assertNotNull(result);

--- a/src/test/java/com/example/petbuddybackend/service/user/ClientServiceTest.java
+++ b/src/test/java/com/example/petbuddybackend/service/user/ClientServiceTest.java
@@ -2,14 +2,12 @@ package com.example.petbuddybackend.service.user;
 
 import com.example.petbuddybackend.dto.user.CaretakerDTO;
 import com.example.petbuddybackend.dto.user.ClientDTO;
-import com.example.petbuddybackend.entity.user.AppUser;
 import com.example.petbuddybackend.entity.user.Caretaker;
 import com.example.petbuddybackend.entity.user.Client;
 import com.example.petbuddybackend.repository.user.AppUserRepository;
 import com.example.petbuddybackend.repository.user.CaretakerRepository;
 import com.example.petbuddybackend.repository.user.ClientRepository;
 import com.example.petbuddybackend.testutils.PersistenceUtils;
-import com.example.petbuddybackend.testutils.mock.MockUserProvider;
 import com.example.petbuddybackend.utils.exception.throweable.general.IllegalActionException;
 import com.example.petbuddybackend.utils.exception.throweable.general.NotFoundException;
 import org.junit.jupiter.api.AfterEach;
@@ -51,25 +49,6 @@ public class ClientServiceTest {
         appUserRepository.deleteAll();
     }
 
-
-    @Test
-    void checkClientExists_shouldReturnTrue() {
-        Client client = MockUserProvider.createMockClient();
-
-        AppUser accountData = PersistenceUtils.addAppUser(appUserRepository, client.getAccountData());
-        client.setEmail(accountData.getEmail());
-        clientRepository.saveAndFlush(client);
-
-        boolean clientExists = clientService.clientExists(client.getAccountData().getEmail());
-        assertNotNull(clientExists);
-    }
-
-    @Test
-    void checkClientExists_noSuchClientPresent_shouldReturnFalse() {
-        boolean clientExists = clientService.clientExists("invalidEmail");
-        assertNotNull(clientExists);
-    }
-
     @Test
     @Transactional
     void createClientIfNotExist_WhenClientDoesNotExist_ThenShouldCreateClient() {
@@ -86,7 +65,6 @@ public class ClientServiceTest {
         assertEquals("test@mail", createdClient.getEmail());
         assertEquals("firstname", createdClient.getAccountData().getName());
         assertEquals("lastname", createdClient.getAccountData().getSurname());
-
     }
 
     @Test

--- a/src/test/java/com/example/petbuddybackend/service/user/ClientServiceTest.java
+++ b/src/test/java/com/example/petbuddybackend/service/user/ClientServiceTest.java
@@ -1,5 +1,6 @@
 package com.example.petbuddybackend.service.user;
 
+import com.example.petbuddybackend.dto.user.CaretakerDTO;
 import com.example.petbuddybackend.dto.user.ClientDTO;
 import com.example.petbuddybackend.entity.user.AppUser;
 import com.example.petbuddybackend.entity.user.Caretaker;
@@ -18,6 +19,7 @@ import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.security.oauth2.server.resource.authentication.JwtAuthenticationToken;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 
@@ -220,6 +222,24 @@ public class ClientServiceTest {
         // When Then
         assertThrows(IllegalActionException.class,
                 () -> clientService.removeFollowingCaretaker(client.getEmail(), caretakers.get(1).getEmail()));
+
+    }
+
+    @Test
+    @Transactional
+    void getFollowedCaretakers_shouldReturnProperAnswer() {
+
+        //Given
+        Client client = PersistenceUtils.addClient(appUserRepository, clientRepository);
+        List<Caretaker> caretakers = addTwoCaretakers();
+        PersistenceUtils.addFollowingCaretakersToClient(clientRepository, client, new HashSet<>(caretakers));
+
+        //When
+        Set<CaretakerDTO> result = clientService.getFollowedCaretakers(client.getEmail());
+
+        //Then
+        assertNotNull(result);
+        assertEquals(2, result.size());
 
     }
 

--- a/src/test/java/com/example/petbuddybackend/testutils/PersistenceUtils.java
+++ b/src/test/java/com/example/petbuddybackend/testutils/PersistenceUtils.java
@@ -241,10 +241,16 @@ public class PersistenceUtils {
         offerRepository.save(offer);
     }
 
-    public static void setAvailabilitiesForOffer(OfferRepository offerRepository, Offer existingOffer, Set<Availability> availabilities) {
+    public static void setAvailabilitiesForOffer(OfferRepository offerRepository, Offer existingOffer,
+                                                 Set<Availability> availabilities) {
         Offer offer = setAvailabilitiesToOffer(existingOffer, availabilities);
         offerRepository.save(offer);
     }
 
+    public static void addFollowingCaretakersToClient(ClientRepository clientRepository, Client client,
+                                                       Set<Caretaker> caretakers) {
+        client.getFollowingCaretakers().addAll(caretakers);
+        clientRepository.saveAndFlush(client);
+    }
 
 }


### PR DESCRIPTION
Dodanie endpointu zwracającego obserwowanych opiekunów przez klienta. Endpoint nie filtruje opiekunów i zwraca ogólne informacje.

Usunięcie ClientService z CaretakerService i zastąpienie ClientRepository w celu unikania zapętleniu zależności.