### PR TITLE
gawron/ZPI-39-ZPI-79-BE-32-Dodanie-endpointów-do-dodawania-konfiguracji-i-udogodnien

### DIFF
--- a/src/main/java/com/example/petbuddybackend/controller/OfferController.java
+++ b/src/main/java/com/example/petbuddybackend/controller/OfferController.java
@@ -17,6 +17,7 @@ import org.springframework.web.bind.annotation.*;
 
 import java.security.Principal;
 import java.util.List;
+import java.util.Set;
 
 @RestController
 @RequiredArgsConstructor
@@ -42,6 +43,44 @@ public class OfferController {
                                    @AcceptRole(acceptRole = Role.CARETAKER)
                                    @RequestHeader(value = "${header-name.role}") Role role) {
         return offerService.addOrEditOffer(offer, principal.getName());
+    }
+
+    @Operation(
+            summary = "Add configurations for offer",
+            description = "Adds configurations for offer. If configuration already exists, it will throw exception." +
+                    " If configuration does not exists, it will be added."
+    )
+    @PostMapping("/{offerId}/add-configurations")
+    @PreAuthorize("isAuthenticated()")
+    public OfferDTO addConfigurationsForOffer(@PathVariable Long offerId,
+                                              @RequestBody List<@Valid ModifyConfigurationDTO> configurations,
+                                              Principal principal,
+
+                                              @RoleParameter
+                                              @AcceptRole(acceptRole = Role.CARETAKER)
+                                              @RequestHeader(value = "${header-name.role}") Role role) {
+
+        return offerService.addConfigurationsForOffer(offerId, configurations, principal.getName());
+
+    }
+
+    @Operation(
+            summary = "Add amenities for offer",
+            description = "Adds amenities for offer. If amenity already exists, it will throw exception." +
+                    " If amenity does not exists, it will be added."
+    )
+    @PostMapping("/{offerId}/add-amenities")
+    @PreAuthorize("isAuthenticated()")
+    public OfferDTO addAmenitiesForOffer(@PathVariable Long offerId,
+                                              @RequestBody Set<String> amenities,
+                                              Principal principal,
+
+                                              @RoleParameter
+                                              @AcceptRole(acceptRole = Role.CARETAKER)
+                                              @RequestHeader(value = "${header-name.role}") Role role) {
+
+        return offerService.addAmenitiesForOffer(offerId, amenities, principal.getName());
+
     }
 
     @Operation(

--- a/src/main/java/com/example/petbuddybackend/controller/OfferController.java
+++ b/src/main/java/com/example/petbuddybackend/controller/OfferController.java
@@ -50,7 +50,7 @@ public class OfferController {
             description = "Adds configurations for offer. If configuration already exists, it will throw exception." +
                     " If configuration does not exists, it will be added."
     )
-    @PostMapping("/{offerId}/add-configurations")
+    @PostMapping("/{offerId}/configurations")
     @PreAuthorize("isAuthenticated()")
     public OfferDTO addConfigurationsForOffer(@PathVariable Long offerId,
                                               @RequestBody List<@Valid ModifyConfigurationDTO> configurations,
@@ -69,7 +69,7 @@ public class OfferController {
             description = "Adds amenities for offer. If amenity already exists, it will throw exception." +
                     " If amenity does not exists, it will be added."
     )
-    @PostMapping("/{offerId}/add-amenities")
+    @PostMapping("/{offerId}/amenities")
     @PreAuthorize("isAuthenticated()")
     public OfferDTO addAmenitiesForOffer(@PathVariable Long offerId,
                                               @RequestBody Set<String> amenities,

--- a/src/main/java/com/example/petbuddybackend/dto/offer/ModifyOfferDTO.java
+++ b/src/main/java/com/example/petbuddybackend/dto/offer/ModifyOfferDTO.java
@@ -6,6 +6,7 @@ import jakarta.validation.constraints.NotNull;
 import lombok.Builder;
 
 import java.util.List;
+import java.util.Set;
 
 @Builder
 public record ModifyOfferDTO(
@@ -15,6 +16,6 @@ public record ModifyOfferDTO(
         @Valid
         AnimalDTO animal,
         List<@Valid ModifyConfigurationDTO> offerConfigurations,
-        List<String> animalAmenities
+        Set<String> animalAmenities
 ) {
 }

--- a/src/main/java/com/example/petbuddybackend/service/offer/OfferService.java
+++ b/src/main/java/com/example/petbuddybackend/service/offer/OfferService.java
@@ -178,7 +178,7 @@ public class OfferService {
             OfferConfiguration configuration = createConfiguration(offerConfiguration, offer);
             checkForDuplicateConfiguration(
                     Stream.concat(
-                        Optional.ofNullable(offer.getOfferConfigurations()).orElse(Collections.emptyList()).stream(),
+                        offer.getOfferConfigurations().stream(),
                         newOfferConfigurations.stream()
                     ).toList(),
                     configuration
@@ -271,7 +271,7 @@ public class OfferService {
             AnimalAmenity newAnimalAmenity = animalService.getAnimalAmenity(animalAmenity, modifiyngOffer.getAnimal().getAnimalType());
             checkDuplicateForAnimalAmenity(
                     Stream.concat(
-                            Optional.ofNullable(modifiyngOffer.getAnimalAmenities()).orElse(Collections.emptySet()).stream(),
+                            modifiyngOffer.getAnimalAmenities().stream(),
                             newAnimalAmenities.stream()
                     ).toList(), newAnimalAmenity
             );

--- a/src/main/java/com/example/petbuddybackend/service/offer/OfferService.java
+++ b/src/main/java/com/example/petbuddybackend/service/offer/OfferService.java
@@ -67,6 +67,32 @@ public class OfferService {
     }
 
     @Transactional
+    public OfferDTO addConfigurationsForOffer(Long offerId, List<ModifyConfigurationDTO> configurations, String caretakerEmail) {
+
+        Offer offer = getOffer(offerId);
+        assertOfferIsModifyingByOwnerCaretaker(offer, caretakerEmail);
+
+        List<OfferConfiguration> offerConfigurations = createAdditionalConfigurationsForOffer(configurations, offer);
+
+        offer.getOfferConfigurations().addAll(offerConfigurations);
+        return offerMapper.mapToOfferDTO(offerRepository.save(offer));
+
+    }
+
+    @Transactional
+    public OfferDTO addAmenitiesForOffer(Long offerId, Set<String> amenities, String caretakerEmail) {
+
+        Offer offer = getOffer(offerId);
+        assertOfferIsModifyingByOwnerCaretaker(offer, caretakerEmail);
+
+        Set<AnimalAmenity> animalAmenities = createAdditionalAnimalAmenitiesForOffer(amenities, offer);
+
+        offer.getAnimalAmenities().addAll(animalAmenities);
+        return offerMapper.mapToOfferDTO(offerRepository.save(offer));
+
+    }
+
+    @Transactional
     public OfferDTO deleteConfiguration(Long configurationId, String userEmail) {
 
         OfferConfiguration offerConfiguration = getOfferConfiguration(configurationId);
@@ -150,10 +176,13 @@ public class OfferService {
         List<OfferConfiguration> newOfferConfigurations = new ArrayList<>();
         for(ModifyConfigurationDTO offerConfiguration : offerConfigurations) {
             OfferConfiguration configuration = createConfiguration(offerConfiguration, offer);
-            checkForDuplicateConfiguration(Stream.concat(
-                    Optional.ofNullable(offer.getOfferConfigurations()).orElse(Collections.emptyList()).stream(),
-                    newOfferConfigurations.stream()
-            ).toList(), configuration);
+            checkForDuplicateConfiguration(
+                    Stream.concat(
+                        Optional.ofNullable(offer.getOfferConfigurations()).orElse(Collections.emptyList()).stream(),
+                        newOfferConfigurations.stream()
+                    ).toList(),
+                    configuration
+            );
 
             newOfferConfigurations.add(configuration);
         }
@@ -235,7 +264,7 @@ public class OfferService {
 
     }
 
-    private Set<AnimalAmenity> createAdditionalAnimalAmenitiesForOffer(List<String> animalAmenities, Offer modifiyngOffer) {
+    private Set<AnimalAmenity> createAdditionalAnimalAmenitiesForOffer(Set<String> animalAmenities, Offer modifiyngOffer) {
 
         List<AnimalAmenity> newAnimalAmenities = new ArrayList<>();
         for(String animalAmenity : animalAmenities) {
@@ -355,4 +384,5 @@ public class OfferService {
             }
         }
     }
+
 }

--- a/src/main/resources/amenity-data.yml
+++ b/src/main/resources/amenity-data.yml
@@ -2,3 +2,4 @@ amenity-data:
   amenityConfigs:
     - amenity: scratching post
     - amenity: toys
+    - amenity: garden

--- a/src/main/resources/animal-amenity-data.yml
+++ b/src/main/resources/animal-amenity-data.yml
@@ -6,3 +6,5 @@ animal-amenity-data:
       amenity: toys
     - animalType: DOG
       amenity: toys
+    - animalType: DOG
+      amenity: garden

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -10,7 +10,7 @@ spring:
     password: ${DB_PASSWORD}
   jpa:
     hibernate:
-      ddl-auto: update
+      ddl-auto: create-drop
     properties:
       dialect: org.hibernate.dialect.PostgreSQL94Dialect
       hibernate:

--- a/src/test/java/com/example/petbuddybackend/controller/OfferControllerTest.java
+++ b/src/test/java/com/example/petbuddybackend/controller/OfferControllerTest.java
@@ -150,7 +150,7 @@ public class OfferControllerTest {
 
 
         // When and Then
-        mockMvc.perform(post("/api/caretaker/offer/1/add-configurations")
+        mockMvc.perform(post("/api/caretaker/offer/1/configurations")
                         .contentType(MediaType.APPLICATION_JSON)
                         .content(ADD_CONFIGURATIONS_FOR_OFFER)
                         .header(roleHeaderName, Role.CARETAKER))
@@ -175,7 +175,7 @@ public class OfferControllerTest {
         when(offerService.addAmenitiesForOffer(anyLong(), anySet(), anyString())).thenReturn(offerDTO);
 
         // When and Then
-        mockMvc.perform(post("/api/caretaker/offer/1/add-amenities")
+        mockMvc.perform(post("/api/caretaker/offer/1/amenities")
                         .contentType(MediaType.APPLICATION_JSON)
                         .content(ADD_AMENITIES_FOR_OFFER)
                         .header(roleHeaderName, Role.CARETAKER))

--- a/src/test/resources/application.yml
+++ b/src/test/resources/application.yml
@@ -1,7 +1,7 @@
 spring:
   jpa:
     hibernate:
-      ddl-auto: create-drop
+      ddl-auto: update
     properties:
       dialect: org.hibernate.dialect.PostgreSQL94Dialect
       order_by.default_null_ordering: last


### PR DESCRIPTION
Wydzielenie endpointów do zarządznia ofertą:

1.  Endpoint do dodawania konfiguracji do oferty
2.  Endpoint do dodawania udogodnień do oferty