### PR TITLE
Cyndzer/ZPI-37-ZPI-21-BE-18-BE-83 Asynchroniczne usuwanie zdjec

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -159,6 +159,7 @@
                             <exclude>com/example/petbuddybackend/config/websocket/**</exclude>
                             <exclude>com/example/petbuddybackend/config/web/WebConfig.class</exclude>
                             <exclude>com/example/petbuddybackend/config/firebase/**</exclude>
+                            <exclude>com/example/petbuddybackend/config/async/AsyncConfig.class</exclude>
                             <exclude>com/example/petbuddybackend/service/datageneration/**</exclude>
                             <exclude>com/example/petbuddybackend/filter/ExceptionHandlerFilter.class</exclude>
                             <exclude>com/example/petbuddybackend/filter/CORSFilter.class</exclude>

--- a/src/main/java/com/example/petbuddybackend/PetBuddyBackendApplication.java
+++ b/src/main/java/com/example/petbuddybackend/PetBuddyBackendApplication.java
@@ -2,10 +2,8 @@ package com.example.petbuddybackend;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
-import org.springframework.scheduling.annotation.EnableScheduling;
 
 @SpringBootApplication
-@EnableScheduling
 public class PetBuddyBackendApplication {
 
     public static void main(String[] args) {

--- a/src/main/java/com/example/petbuddybackend/config/async/AsyncConfig.java
+++ b/src/main/java/com/example/petbuddybackend/config/async/AsyncConfig.java
@@ -1,0 +1,14 @@
+package com.example.petbuddybackend.config.async;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Profile;
+import org.springframework.scheduling.annotation.AsyncConfigurer;
+import org.springframework.scheduling.annotation.EnableAsync;
+import org.springframework.scheduling.annotation.EnableScheduling;
+
+@Profile("dev | prod")
+@EnableAsync
+@EnableScheduling
+@Configuration
+public class AsyncConfig implements AsyncConfigurer {
+}

--- a/src/main/java/com/example/petbuddybackend/controller/UserController.java
+++ b/src/main/java/com/example/petbuddybackend/controller/UserController.java
@@ -40,7 +40,7 @@ public class UserController {
         return userService.getProfileData(principal.getName());
     }
 
-    @PostMapping(value = "/profile-picture", consumes = {MediaType.MULTIPART_FORM_DATA_VALUE})
+    @PutMapping(value = "/profile-picture", consumes = {MediaType.MULTIPART_FORM_DATA_VALUE})
     @Operation(
             summary = "Upload profile picture",
             description = """

--- a/src/main/java/com/example/petbuddybackend/dto/rating/RatingResponse.java
+++ b/src/main/java/com/example/petbuddybackend/dto/rating/RatingResponse.java
@@ -1,7 +1,9 @@
 package com.example.petbuddybackend.dto.rating;
 
+import com.example.petbuddybackend.dto.user.ClientDTO;
+
 public record RatingResponse(
-        String clientEmail,
+        ClientDTO client,
         String caretakerEmail,
         Integer rating,
         String comment

--- a/src/main/java/com/example/petbuddybackend/entity/photo/PhotoLink.java
+++ b/src/main/java/com/example/petbuddybackend/entity/photo/PhotoLink.java
@@ -26,4 +26,6 @@ public class PhotoLink {
 
     @Column(nullable = false)
     private LocalDateTime urlExpiresAt;
+
+    private LocalDateTime markedForDeletionAt;
 }

--- a/src/main/java/com/example/petbuddybackend/repository/photo/PhotoLinkRepository.java
+++ b/src/main/java/com/example/petbuddybackend/repository/photo/PhotoLinkRepository.java
@@ -4,6 +4,10 @@ import com.example.petbuddybackend.entity.photo.PhotoLink;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
+import java.util.List;
+
 @Repository
 public interface PhotoLinkRepository extends JpaRepository<PhotoLink, String> {
+
+    List<PhotoLink> getAllByMarkedForDeletionAtNotNull();
 }

--- a/src/main/java/com/example/petbuddybackend/scheduled/PhotoDeletionScheduled.java
+++ b/src/main/java/com/example/petbuddybackend/scheduled/PhotoDeletionScheduled.java
@@ -1,0 +1,27 @@
+package com.example.petbuddybackend.scheduled;
+
+import com.example.petbuddybackend.entity.photo.PhotoLink;
+import com.example.petbuddybackend.repository.photo.PhotoLinkRepository;
+import com.example.petbuddybackend.service.photo.PhotoService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.scheduling.annotation.Scheduled;
+
+import java.util.List;
+
+@Configuration
+@RequiredArgsConstructor
+@Slf4j
+public class PhotoDeletionScheduled {
+
+    private final PhotoService photoService;
+    private final PhotoLinkRepository photoRepository;
+
+    @Scheduled(cron = "0 1 0 * * *")
+    public void terminateCares() {
+        List<PhotoLink> photosToDelete = photoRepository.getAllByMarkedForDeletionAtNotNull();
+        log.info("Deleting {} photos", photosToDelete.size());
+        photoService.schedulePhotoDeletions(photosToDelete);
+    }
+}

--- a/src/main/java/com/example/petbuddybackend/scheduled/PhotoDeletionScheduled.java
+++ b/src/main/java/com/example/petbuddybackend/scheduled/PhotoDeletionScheduled.java
@@ -19,7 +19,7 @@ public class PhotoDeletionScheduled {
     private final PhotoLinkRepository photoRepository;
 
     @Scheduled(cron = "0 1 0 * * *")
-    public void terminateCares() {
+    public void terminatePhotos() {
         List<PhotoLink> photosToDelete = photoRepository.getAllByMarkedForDeletionAtNotNull();
         log.info("Deleting {} photos", photosToDelete.size());
         photoService.schedulePhotoDeletions(photosToDelete);

--- a/src/main/java/com/example/petbuddybackend/service/mapper/ClientMapper.java
+++ b/src/main/java/com/example/petbuddybackend/service/mapper/ClientMapper.java
@@ -5,7 +5,7 @@ import com.example.petbuddybackend.entity.user.Client;
 import org.mapstruct.Mapper;
 import org.mapstruct.factory.Mappers;
 
-@Mapper(uses = {AddressMapper.class, UserMapper.class})
+@Mapper(uses = {UserMapper.class})
 public interface ClientMapper {
 
     ClientMapper INSTANCE = Mappers.getMapper(ClientMapper.class);

--- a/src/main/java/com/example/petbuddybackend/service/mapper/RatingMapper.java
+++ b/src/main/java/com/example/petbuddybackend/service/mapper/RatingMapper.java
@@ -5,7 +5,7 @@ import com.example.petbuddybackend.entity.rating.Rating;
 import org.mapstruct.Mapper;
 import org.mapstruct.factory.Mappers;
 
-@Mapper
+@Mapper(uses = {ClientMapper.class})
 public interface RatingMapper {
 
     RatingMapper INSTANCE = Mappers.getMapper(RatingMapper.class);

--- a/src/main/java/com/example/petbuddybackend/service/photo/FirebasePhotoService.java
+++ b/src/main/java/com/example/petbuddybackend/service/photo/FirebasePhotoService.java
@@ -29,7 +29,6 @@ import java.util.concurrent.TimeUnit;
 @RequiredArgsConstructor
 public class FirebasePhotoService implements PhotoService {
 
-    private final static String MISSING_FILE_EXTENSION = "Missing file extension";
     private final static String PHOTO = "Photo";
     private static final Set<String> acceptedImageTypes = Set.of(
             "image/jpeg",
@@ -168,21 +167,10 @@ public class FirebasePhotoService implements PhotoService {
          }
      }
 
-    /**
-     * @return Extension of the file like .jpg, .png, .jpeg
-     * */
-    private String getExtension(String fileName) {
-        if(fileName == null) {
-            throw new InvalidPhotoException(MISSING_FILE_EXTENSION);
-        }
-
-        return fileName.substring(fileName.lastIndexOf("."));
-    }
-
     private PhotoLink uploadFile(MultipartFile file, int expirationSeconds) {
         StorageClient storageClient = StorageClient.getInstance(firebaseApp);
         Bucket bucket = storageClient.bucket();
-        String filename = UUID.randomUUID() + getExtension(file.getOriginalFilename());
+        String filename = UUID.randomUUID().toString();
         String blobPath = PHOTO_DIRECTORY + "/" + filename;
 
         try {

--- a/src/main/java/com/example/petbuddybackend/service/photo/FirebasePhotoService.java
+++ b/src/main/java/com/example/petbuddybackend/service/photo/FirebasePhotoService.java
@@ -6,14 +6,15 @@ import com.example.petbuddybackend.utils.exception.throweable.general.NotFoundEx
 import com.example.petbuddybackend.utils.exception.throweable.photo.InvalidPhotoException;
 import com.google.cloud.storage.Blob;
 import com.google.cloud.storage.Bucket;
+import com.google.cloud.storage.StorageException;
 import com.google.firebase.FirebaseApp;
 import com.google.firebase.cloud.StorageClient;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.tika.Tika;
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.scheduling.annotation.Async;
 import org.springframework.stereotype.Service;
-import org.springframework.transaction.annotation.Propagation;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.multipart.MultipartFile;
 
@@ -22,7 +23,6 @@ import java.io.InputStream;
 import java.time.LocalDateTime;
 import java.util.*;
 import java.util.concurrent.TimeUnit;
-
 
 @Slf4j
 @Service
@@ -49,7 +49,6 @@ public class FirebasePhotoService implements PhotoService {
     private final FirebaseApp firebaseApp;
     private final PhotoLinkRepository photoRepository;
     private final Tika tika;
-
 
     @Override
     public Optional<PhotoLink> findPhotoLinkByNullableId(String blob) {
@@ -94,28 +93,20 @@ public class FirebasePhotoService implements PhotoService {
     }
 
     @Override
-    @Transactional
-    public void deletePhoto(String blob) {
-        Optional<PhotoLink> photo = findPhotoLinkByNullableId(blob);
-
-        if(photo.isEmpty()) {
-            return;
+    @Async
+    public void schedulePhotoDeletion(PhotoLink photoLink) {
+        try {
+            photoRepository.delete(photoLink);
+            removePhotoFromCloud(photoLink.getBlob());
+        } catch(StorageException e) {
+            handleStorageException(e, photoLink);
+            throw e;
         }
-
-        deletePhoto(photo.get());
     }
 
     @Override
-    @Transactional(propagation = Propagation.REQUIRES_NEW)
-    public void deletePhoto(PhotoLink photoLink) {
-        photoRepository.delete(photoLink);
-        removePhotoFromCloud(photoLink.getBlob());
-    }
-
-    @Override
-    @Transactional
-    public void deletePhotos(Collection<PhotoLink> photoLinksToDelete) {
-        photoLinksToDelete.forEach(this::deletePhoto);
+    public void schedulePhotoDeletions(Collection<PhotoLink> photoLinksToDelete) {
+        photoLinksToDelete.forEach(this::schedulePhotoDeletion);
     }
 
     @Override
@@ -132,6 +123,19 @@ public class FirebasePhotoService implements PhotoService {
         return photoRepository.saveAll(photosRenewed);
     }
 
+    private void handleStorageException(StorageException e, PhotoLink photoLink) {
+        log.warn("StorageException occurred while deleting photo: {}", e.getMessage());
+
+        if(e.getCode() == 404) {
+            log.warn("Photo {} not found in cloud storage. Deleting from database", photoLink.getBlob());
+            photoRepository.delete(photoLink);
+        } else {
+            log.error("Failed to delete photo {}. Status code: {}. Marking for deletion", e.getCode(), photoLink.getBlob());
+            photoLink.setMarkedForDeletionAt(LocalDateTime.now());
+            photoRepository.save(photoLink);
+        }
+    }
+
     private void removePhotoFromCloud(String blob) {
         StorageClient storageClient = StorageClient.getInstance(firebaseApp);
         Bucket bucket = storageClient.bucket();
@@ -145,26 +149,26 @@ public class FirebasePhotoService implements PhotoService {
     /**
      * Checks if the provided file is not empty and if its type matches the accepted types defined in the acceptedImageTypes set.
      * */
-     private void validatePhoto(MultipartFile multipartFile) {
-         if (multipartFile == null || multipartFile.isEmpty()) {
-             throw InvalidPhotoException.ofEmptyPhoto();
-         }
+    private void validatePhoto(MultipartFile multipartFile) {
+        if (multipartFile == null || multipartFile.isEmpty()) {
+            throw InvalidPhotoException.ofEmptyPhoto();
+        }
 
-         try(InputStream inputStream = multipartFile.getInputStream()) {
-             String mimeType = tika.detect(inputStream);
+        try(InputStream inputStream = multipartFile.getInputStream()) {
+            String mimeType = tika.detect(inputStream);
 
-             if(!acceptedImageTypes.contains(mimeType)) {
-                 throw InvalidPhotoException.ofPhotoWithInvalidExtension(
-                         multipartFile.getOriginalFilename(),
-                         mimeType,
-                         acceptedImageTypes
-                 );
-             }
+            if(!acceptedImageTypes.contains(mimeType)) {
+                throw InvalidPhotoException.ofPhotoWithInvalidExtension(
+                        multipartFile.getOriginalFilename(),
+                        mimeType,
+                        acceptedImageTypes
+                );
+            }
 
-         } catch (IOException e) {
-             throw InvalidPhotoException.ofInvalidPhoto(multipartFile.getOriginalFilename());
-         }
-     }
+        } catch (IOException e) {
+            throw InvalidPhotoException.ofInvalidPhoto(multipartFile.getOriginalFilename());
+        }
+    }
 
     private PhotoLink uploadFile(MultipartFile file, int expirationSeconds) {
         StorageClient storageClient = StorageClient.getInstance(firebaseApp);
@@ -213,3 +217,4 @@ public class FirebasePhotoService implements PhotoService {
         return photo;
     }
 }
+

--- a/src/main/java/com/example/petbuddybackend/service/photo/FirebasePhotoService.java
+++ b/src/main/java/com/example/petbuddybackend/service/photo/FirebasePhotoService.java
@@ -29,7 +29,6 @@ import java.util.concurrent.TimeUnit;
 @RequiredArgsConstructor
 public class FirebasePhotoService implements PhotoService {
 
-    private final static String MISSING_FILE_EXTENSION = "Missing file extension";
     private final static String PHOTO = "Photo";
     private static final Set<String> acceptedImageTypes = Set.of(
             "image/jpeg",
@@ -167,21 +166,10 @@ public class FirebasePhotoService implements PhotoService {
          }
      }
 
-    /**
-     * @return Extension of the file like .jpg, .png, .jpeg
-     * */
-    private String getExtension(String fileName) {
-        if(fileName == null) {
-            throw new InvalidPhotoException(MISSING_FILE_EXTENSION);
-        }
-
-        return fileName.substring(fileName.lastIndexOf("."));
-    }
-
     private PhotoLink uploadFile(MultipartFile file, int expirationSeconds) {
         StorageClient storageClient = StorageClient.getInstance(firebaseApp);
         Bucket bucket = storageClient.bucket();
-        String filename = UUID.randomUUID() + getExtension(file.getOriginalFilename());
+        String filename = UUID.randomUUID().toString();
         String blobPath = PHOTO_DIRECTORY + "/" + filename;
 
         try {

--- a/src/main/java/com/example/petbuddybackend/service/photo/FirebasePhotoService.java
+++ b/src/main/java/com/example/petbuddybackend/service/photo/FirebasePhotoService.java
@@ -96,8 +96,8 @@ public class FirebasePhotoService implements PhotoService {
     @Async
     public void schedulePhotoDeletion(PhotoLink photoLink) {
         try {
-            photoRepository.delete(photoLink);
             removePhotoFromCloud(photoLink.getBlob());
+            photoRepository.delete(photoLink);
         } catch(StorageException e) {
             handleStorageException(e, photoLink);
             throw e;

--- a/src/main/java/com/example/petbuddybackend/service/photo/PhotoService.java
+++ b/src/main/java/com/example/petbuddybackend/service/photo/PhotoService.java
@@ -17,7 +17,9 @@ public interface PhotoService {
     @Async
     void schedulePhotoDeletion(PhotoLink photoLink);
 
-    @Async
+    /**
+     * Schedules deletion of multiple photos asynchronously.
+     * */
     void schedulePhotoDeletions(Collection<PhotoLink> photoLinksToDelete);
 
     PhotoLink updatePhotoExpiration(PhotoLink photo);

--- a/src/main/java/com/example/petbuddybackend/service/photo/PhotoService.java
+++ b/src/main/java/com/example/petbuddybackend/service/photo/PhotoService.java
@@ -1,6 +1,7 @@
 package com.example.petbuddybackend.service.photo;
 
 import com.example.petbuddybackend.entity.photo.PhotoLink;
+import org.springframework.scheduling.annotation.Async;
 import org.springframework.web.multipart.MultipartFile;
 
 import java.util.Collection;
@@ -13,11 +14,11 @@ public interface PhotoService {
 
     List<PhotoLink> uploadPhotos(List<MultipartFile> multipartFiles);
 
-    void deletePhoto(String blob);
+    @Async
+    void schedulePhotoDeletion(PhotoLink photoLink);
 
-    void deletePhoto(PhotoLink photoLink);
-
-    void deletePhotos(Collection<PhotoLink> photoLinksToDelete);
+    @Async
+    void schedulePhotoDeletions(Collection<PhotoLink> photoLinksToDelete);
 
     PhotoLink updatePhotoExpiration(PhotoLink photo);
 

--- a/src/main/java/com/example/petbuddybackend/service/user/CaretakerService.java
+++ b/src/main/java/com/example/petbuddybackend/service/user/CaretakerService.java
@@ -164,7 +164,7 @@ public class CaretakerService {
         caretaker.getOfferPhotos().removeAll(photosToRemove);
         assertOfferPhotoCountWithinLimit(caretaker.getOfferPhotos().size() + newPhotos.size());
         caretaker.getOfferPhotos().addAll(photoService.uploadPhotos(newPhotos));
-        photoService.deletePhotos(photosToRemove);
+        photoService.schedulePhotoDeletions(photosToRemove);
     }
 
     private Caretaker renewCaretakerPictures(Caretaker caretaker) {

--- a/src/main/java/com/example/petbuddybackend/service/user/CaretakerService.java
+++ b/src/main/java/com/example/petbuddybackend/service/user/CaretakerService.java
@@ -135,7 +135,7 @@ public class CaretakerService {
         caretaker.getOfferPhotos().removeAll(photosToRemove);
         assertOfferPhotoCountWithinLimit(caretaker.getOfferPhotos().size() + newPhotos.size());
         caretaker.getOfferPhotos().addAll(photoService.uploadPhotos(newPhotos));
-        photoService.deletePhotos(photosToRemove);
+        photoService.schedulePhotoDeletions(photosToRemove);
     }
 
     private Caretaker renewCaretakerPictures(Caretaker caretaker) {

--- a/src/main/java/com/example/petbuddybackend/service/user/UserService.java
+++ b/src/main/java/com/example/petbuddybackend/service/user/UserService.java
@@ -79,8 +79,10 @@ public class UserService {
         AppUser user = getAppUser(username);
         PhotoLink oldPhoto = user.getProfilePicture();
 
-        if(oldPhoto != null) {
-            photoService.deletePhoto(oldPhoto);
+        if (oldPhoto != null) {
+            user.setProfilePicture(null);
+            userRepository.save(user);
+            photoService.schedulePhotoDeletion(oldPhoto);
         }
 
         PhotoLink newPhoto = photoService.uploadPhoto(profilePicture);
@@ -97,7 +99,7 @@ public class UserService {
             return;
         }
 
-        photoService.deletePhoto(profilePicture);
+        photoService.schedulePhotoDeletion(profilePicture);
         user.setProfilePicture(null);
         userRepository.save(user);
     }

--- a/src/main/java/com/example/petbuddybackend/service/user/UserService.java
+++ b/src/main/java/com/example/petbuddybackend/service/user/UserService.java
@@ -84,8 +84,10 @@ public class UserService {
         AppUser user = getAppUser(username);
         PhotoLink oldPhoto = user.getProfilePicture();
 
-        if(oldPhoto != null) {
-            photoService.deletePhoto(oldPhoto);
+        if (oldPhoto != null) {
+            user.setProfilePicture(null);
+            userRepository.save(user);
+            photoService.schedulePhotoDeletion(oldPhoto);
         }
 
         PhotoLink newPhoto = photoService.uploadPhoto(profilePicture);
@@ -102,7 +104,7 @@ public class UserService {
             return;
         }
 
-        photoService.deletePhoto(profilePicture);
+        photoService.schedulePhotoDeletion(profilePicture);
         user.setProfilePicture(null);
         userRepository.save(user);
     }

--- a/src/test/java/com/example/petbuddybackend/controller/UserControllerTest.java
+++ b/src/test/java/com/example/petbuddybackend/controller/UserControllerTest.java
@@ -92,7 +92,12 @@ public class UserControllerTest {
         // then
         mockMvc.perform(multipart("/api/user/profile-picture")
                         .file(mockFile)
-                        .with(user(USERNAME)))
+                        .with(user(USERNAME))
+                        .with(request -> {
+                            request.setMethod("PUT");
+                            return request;
+                        })
+                )
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.email").value(USERNAME))
                 .andExpect(jsonPath("$.profilePicture.url").value(url))
@@ -104,7 +109,12 @@ public class UserControllerTest {
     void uploadProfilePicture_noPictureProvided_shouldReturn400() throws Exception {
         // then
         mockMvc.perform(multipart("/api/user/profile-picture")
-                        .with(user(USERNAME)))
+                        .with(user(USERNAME))
+                        .with(request -> {
+                            request.setMethod("PUT");
+                            return request;
+                        })
+                )
                 .andExpect(status().isBadRequest());
     }
 

--- a/src/test/java/com/example/petbuddybackend/scheduled/PhotoDeletionScheduledIntegrationTest.java
+++ b/src/test/java/com/example/petbuddybackend/scheduled/PhotoDeletionScheduledIntegrationTest.java
@@ -1,0 +1,66 @@
+package com.example.petbuddybackend.scheduled;
+
+import com.example.petbuddybackend.entity.photo.PhotoLink;
+import com.example.petbuddybackend.repository.photo.PhotoLinkRepository;
+import com.google.cloud.storage.Bucket;
+import com.google.firebase.FirebaseApp;
+import com.google.firebase.cloud.StorageClient;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mock;
+import org.mockito.MockedStatic;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+import static org.mockito.Mockito.mockStatic;
+import static org.mockito.Mockito.when;
+
+@SpringBootTest
+public class PhotoDeletionScheduledIntegrationTest {
+
+    @Autowired
+    private PhotoDeletionScheduled photoDeletionScheduled;
+
+    @Autowired
+    private PhotoLinkRepository photoRepository;
+
+    @MockBean
+    private FirebaseApp firebaseApp;
+
+    @Mock
+    private StorageClient mockStorageClient;
+
+    @Mock
+    private Bucket mockBucket;
+
+    private MockedStatic<StorageClient> storageClientMock;
+
+    @BeforeEach
+    void setUp() {
+        storageClientMock = mockStatic(StorageClient.class);
+        when(StorageClient.getInstance(firebaseApp)).thenReturn(mockStorageClient);
+        when(mockStorageClient.bucket()).thenReturn(mockBucket);
+    }
+
+    @AfterEach
+    void tearDown() {
+        storageClientMock.close();
+    }
+
+    @Test
+    void testRemovePhotosMarkedForDeletion_shouldSucceed() {
+        List<PhotoLink> photosToDelete = List.of(
+                new PhotoLink("1", "photo1", LocalDateTime.now(), null),
+                new PhotoLink("2", "photo2", LocalDateTime.now(), LocalDateTime.now().minusDays(10)),
+                new PhotoLink("1", "photo1", LocalDateTime.now(), LocalDateTime.now().plusDays(10)),
+                new PhotoLink("2", "photo2", LocalDateTime.now(), LocalDateTime.now())
+        );
+        photoRepository.saveAll(photosToDelete);
+        photoDeletionScheduled.terminateCares();
+    }
+}

--- a/src/test/java/com/example/petbuddybackend/scheduled/PhotoDeletionScheduledIntegrationTest.java
+++ b/src/test/java/com/example/petbuddybackend/scheduled/PhotoDeletionScheduledIntegrationTest.java
@@ -61,6 +61,6 @@ public class PhotoDeletionScheduledIntegrationTest {
                 new PhotoLink("2", "photo2", LocalDateTime.now(), LocalDateTime.now())
         );
         photoRepository.saveAll(photosToDelete);
-        photoDeletionScheduled.terminateCares();
+        photoDeletionScheduled.terminatePhotos();
     }
 }

--- a/src/test/java/com/example/petbuddybackend/service/mapper/RatingMapperTest.java
+++ b/src/test/java/com/example/petbuddybackend/service/mapper/RatingMapperTest.java
@@ -11,8 +11,7 @@ import org.junit.jupiter.api.Test;
 
 import static com.example.petbuddybackend.testutils.mock.MockAnimalProvider.createMockAnimal;
 import static com.example.petbuddybackend.testutils.mock.MockCareProvider.createMockCare;
-import static com.example.petbuddybackend.testutils.mock.MockUserProvider.createMockCaretaker;
-import static com.example.petbuddybackend.testutils.mock.MockUserProvider.createMockClient;
+import static com.example.petbuddybackend.testutils.mock.MockUserProvider.*;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class RatingMapperTest {
@@ -22,7 +21,7 @@ public class RatingMapperTest {
 
     @Test
     void mapToCaretakerDTO_shouldNotLeaveNullFields() throws IllegalAccessException {
-        Client client = createMockClient();
+        Client client = createMockClientWithPhoto("clientEmail");
         Caretaker caretaker = createMockCaretaker();
         Care care = createMockCare(caretaker, client, createMockAnimal("DOG"));
 

--- a/src/test/java/com/example/petbuddybackend/service/photo/PhotoServiceTest.java
+++ b/src/test/java/com/example/petbuddybackend/service/photo/PhotoServiceTest.java
@@ -212,7 +212,7 @@ public class PhotoServiceTest {
         when(mockBlob.delete()).thenThrow(exception);
 
         assertThrows(StorageException.class, () -> firebasePhotoService.schedulePhotoDeletion(photoLink));
-        verify(photoRepository, times(2)).delete(photoLink);
+        verify(photoRepository, times(1)).delete(photoLink);
     }
 
     @Test

--- a/src/test/java/com/example/petbuddybackend/service/user/UserServiceTest.java
+++ b/src/test/java/com/example/petbuddybackend/service/user/UserServiceTest.java
@@ -45,6 +45,7 @@ public class UserServiceTest {
             "testBlob",
             "testURL",
             LocalDateTime.now()
+            , null
     );
 
     @Mock
@@ -118,7 +119,7 @@ public class UserServiceTest {
     @Test
     void getProfileData_shouldSucceed() {
         // Given
-        PhotoLink existingProfilePicture = new PhotoLink("oldBlob", "oldURL", LocalDateTime.now());
+        PhotoLink existingProfilePicture = new PhotoLink("oldBlob", "oldURL", LocalDateTime.now(), null);
         AppUser userWithPicture = AppUser.builder()
                 .email(EMAIL)
                 .profilePicture(existingProfilePicture)
@@ -205,8 +206,8 @@ public class UserServiceTest {
         userService.uploadProfilePicture(USERNAME, profilePicture);
 
         // Then
-        verify(userRepository).save(userCaptor.capture());
-        verify(photoService).deletePhoto(photoLink);
+        verify(userRepository, times(2)).save(userCaptor.capture());
+        verify(photoService).schedulePhotoDeletion(photoLink);
         AppUser savedUser = userCaptor.getValue();
         assertEquals(newPhoto, savedUser.getProfilePicture());
     }
@@ -237,7 +238,7 @@ public class UserServiceTest {
         verify(userRepository).save(userCaptor.capture());
         AppUser savedUser = userCaptor.getValue();
         assertNull(savedUser.getProfilePicture());
-        verify(photoService).deletePhoto(photoLink);
+        verify(photoService).schedulePhotoDeletion(photoLink);
     }
 
     @Test
@@ -253,7 +254,7 @@ public class UserServiceTest {
 
         // Then
         verify(userRepository, never()).save(any(AppUser.class));
-        verify(photoService, never()).deletePhoto(any(String.class));
+        verify(photoService, never()).schedulePhotoDeletion(any(PhotoLink.class));
     }
 
     @Test
@@ -263,7 +264,7 @@ public class UserServiceTest {
 
         // When & Then
         assertThrows(NotFoundException.class, () -> userService.deleteProfilePicture(EMAIL));
-        verify(photoService, never()).deletePhoto(any(String.class));
+        verify(photoService, never()).schedulePhotoDeletion(any(PhotoLink.class));
     }
 
     @Test

--- a/src/test/java/com/example/petbuddybackend/testutils/mock/MockUserProvider.java
+++ b/src/test/java/com/example/petbuddybackend/testutils/mock/MockUserProvider.java
@@ -88,7 +88,24 @@ public final class MockUserProvider {
                 .build();
     }
 
+    public static Client createMockClientWithPhoto(String clientEmail) {
+        AppUser accountData = createMockAppUserWithPhoto("clientName", "clientSurname", clientEmail);
+
+        return Client.builder()
+                .email(clientEmail)
+                .accountData(accountData)
+                .build();
+    }
+
     public static AppUser createMockAppUser(String name, String surname, String email) {
+        return AppUser.builder()
+                .name(name)
+                .surname(surname)
+                .email(email)
+                .build();
+    }
+
+    public static AppUser createMockAppUserWithPhoto(String name, String surname, String email) {
         return AppUser.builder()
                 .name(name)
                 .surname(surname)

--- a/src/test/java/com/example/petbuddybackend/testutils/mock/MockUserProvider.java
+++ b/src/test/java/com/example/petbuddybackend/testutils/mock/MockUserProvider.java
@@ -93,6 +93,7 @@ public final class MockUserProvider {
                 .name(name)
                 .surname(surname)
                 .email(email)
+                .profilePicture(createMockPhotoLink())
                 .build();
     }
 


### PR DESCRIPTION
- zmiana z `POST` na `PUT` dla `/api/user/profile-picture` z racji, że jest to operacja "utwórz lub podmień"
- rezygnacja z przechowywania rozszerzeń w chmurze dla nazw plików
- bugfix podmiany zdjęcia profilowego jeśli już istnieje

Jeśli chodzi o ten bugfix, to polegał on na tym, że nie byłem w stanie ustawić transakcji z `REQUIRES_NEW` dla podmiany zdjęcia profilowego bo Spring czepiał się że zdjęcie jest już przypisane do zdjęcia. Rozwiązałem to robiąc operację asynchroniczną, czyli nie przejmuje się wynikiem usuwania. 

Chciałem dodać do tego mechanizm retry ale przeczytałem, że firebase dla niektórych błędów wynikających z ich strony sam próbuje robić retry. Jedynie co to zroibłem, że jak już błąd wyniknąłby z naszej strony, to oznaczam zdjęcie jako do usunięcia plus podaje logi dlaczego się nie usunęło.

Jedynie obsługuję kod 404, bo oznacza on że takiego zdjęcia w chmurze nie ma, czyli jakimś trafem przechowujemy "śmieci" w bazie danych więc ten rekord po prostu usuwam.