### PR TITLE
Cyndzer/ZPI-42-ZPI-64-BE-88-BE-91 Zmiana logiki statusów opieki

### DIFF
--- a/src/main/java/com/example/petbuddybackend/controller/CareController.java
+++ b/src/main/java/com/example/petbuddybackend/controller/CareController.java
@@ -122,6 +122,30 @@ public class CareController {
         return careService.updateCare(careId, updateCare, principal.getName(), TimeUtils.getOrSystemDefault(timeZone));
     }
 
+    @PostMapping("/{careId}/complete")
+    @Operation(
+            summary = "Mark care as completed",
+            description = """
+                    Caretaker marks care as completed.
+                    
+                    The care must be in the READY_TO_PROCEED status for caretaker to complete.
+                    When successful both statuses changes to COMPLETED.
+                    
+                    The care must be marked as completed by caretaker the same day the care starts.
+                    """
+    )
+    @PreAuthorize("isAuthenticated()")
+    public DetailedCareDTO markCareAsCompleted(
+            @AcceptRole(acceptRole = Role.CARETAKER)
+            @RequestHeader(value = "${header-name.role}") Role role,
+            Principal principal,
+            @TimeZoneParameter @RequestHeader(value = "${header-name.timezone}", required = false) String timeZone,
+            @PathVariable Long careId
+    ) {
+        return careService.markCareAsCompleted(careId, principal.getName(), role, TimeUtils.getOrSystemDefault(timeZone));
+    }
+
+
     @PostMapping("/{careId}/accept")
     @Operation(
             summary = "Accept a care",
@@ -130,7 +154,7 @@ public class CareController {
                     caretaker.
                     
                     The care must be in the PENDING status for caretaker and ACCEPT status for client to accept.
-                    When successful both statuses changes to AWAITING_PAYMENT.
+                    When successful both statuses changes to READY_TO_PROCEED.
                     """
     )
     @ApiResponses(value = {

--- a/src/main/java/com/example/petbuddybackend/controller/CareController.java
+++ b/src/main/java/com/example/petbuddybackend/controller/CareController.java
@@ -122,27 +122,27 @@ public class CareController {
         return careService.updateCare(careId, updateCare, principal.getName(), TimeUtils.getOrSystemDefault(timeZone));
     }
 
-    @PostMapping("/{careId}/complete")
+    @PostMapping("/{careId}/confirm")
     @Operation(
-            summary = "Mark care as completed",
+            summary = "Mark care as confirmed",
             description = """
-                    Caretaker marks care as completed.
+                    Caretaker marks care as confirmed.
                     
-                    The care must be in the READY_TO_PROCEED status for caretaker to complete.
-                    When successful both statuses changes to COMPLETED.
+                    The care must be in the READY_TO_PROCEED status for caretaker to confirmed.
+                    When successful both statuses changes to CONFIRMED.
                     
-                    The care must be marked as completed by caretaker the same day the care starts.
+                    The care must be marked as confirmed by caretaker the same day the care starts.
                     """
     )
     @PreAuthorize("isAuthenticated()")
-    public DetailedCareDTO markCareAsCompleted(
+    public DetailedCareDTO markCareAsConfirmed(
             @AcceptRole(acceptRole = Role.CARETAKER)
             @RequestHeader(value = "${header-name.role}") Role role,
             Principal principal,
             @TimeZoneParameter @RequestHeader(value = "${header-name.timezone}", required = false) String timeZone,
             @PathVariable Long careId
     ) {
-        return careService.markCareAsCompleted(careId, principal.getName(), role, TimeUtils.getOrSystemDefault(timeZone));
+        return careService.markCareAsConfirmed(careId, principal.getName(), role, TimeUtils.getOrSystemDefault(timeZone));
     }
 
 

--- a/src/main/java/com/example/petbuddybackend/entity/care/CareStatus.java
+++ b/src/main/java/com/example/petbuddybackend/entity/care/CareStatus.java
@@ -4,7 +4,7 @@ public enum CareStatus {
     PENDING,
     ACCEPTED,
     READY_TO_PROCEED,
-    COMPLETED,
+    CONFIRMED,
     CANCELLED,
     OUTDATED
 }

--- a/src/main/java/com/example/petbuddybackend/entity/care/CareStatus.java
+++ b/src/main/java/com/example/petbuddybackend/entity/care/CareStatus.java
@@ -3,8 +3,8 @@ package com.example.petbuddybackend.entity.care;
 public enum CareStatus {
     PENDING,
     ACCEPTED,
-    AWAITING_PAYMENT,
-    PAID,
+    READY_TO_PROCEED,
+    COMPLETED,
     CANCELLED,
     OUTDATED
 }

--- a/src/main/java/com/example/petbuddybackend/repository/care/CareRepository.java
+++ b/src/main/java/com/example/petbuddybackend/repository/care/CareRepository.java
@@ -12,6 +12,7 @@ import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.time.LocalDate;
 import java.util.Collection;
 import java.util.List;
 
@@ -48,10 +49,10 @@ public interface CareRepository extends JpaRepository<Care, Long>, JpaSpecificat
                 c.clientStatus = com.example.petbuddybackend.entity.care.CareStatus.OUTDATED
             WHERE c.caretakerStatus IN :statusesPrerequisites
             AND c.clientStatus IN :statusesPrerequisites
-            AND c.careStart < CURRENT_DATE
+            AND c.careStart < :threshold
             """
     )
-    int outdateCaresBetweenClientAndCaretaker(Collection<CareStatus> statusesPrerequisites);
+    int outdateCaresBetweenClientAndCaretaker(Collection<CareStatus> statusesPrerequisites, LocalDate threshold);
 
     @Query("""
             SELECT new com.example.petbuddybackend.dto.user.SimplifiedAccountDataDTO(

--- a/src/main/java/com/example/petbuddybackend/service/care/CareService.java
+++ b/src/main/java/com/example/petbuddybackend/service/care/CareService.java
@@ -39,12 +39,8 @@ import java.util.Set;
 public class CareService {
 
     private static final String CARE = "Care";
-    private static final String ATTRIBUTE_MISMATCH_FORMAT = "%s (attribute: %s)";
     private static final String CARETAKER_NOT_OWNER_MESSAGE = "Caretaker is not owner of the care";
     private static final String CLIENT_NOT_OWNER_MESSAGE = "Client is not owner of the care";
-    private static final String ANIMAL_ATTRIBUTE_MISMATCH_MESSAGE = "Animal attributes must match animal type." +
-            " Mismatches: %s";
-
     private static final String CREATE_RESERVATION_MESSAGE = "message.care.reservation";
     private static final String UPDATE_RESERVATION_MESSAGE = "message.care.update_reservation";
     private static final String ACCEPT_RESERVATION_MESSAGE = "message.care.accepted_reservation";
@@ -142,6 +138,13 @@ public class CareService {
         Care care = getCareById(careId);
         assertUserParticipatingInCare(care, userEmail);
         return careMapper.mapToDetailedCareDTO(care, timezone);
+    }
+
+    public DetailedCareDTO markCareAsCompleted(Long careId, String name, Role role, ZoneId orSystemDefault) {
+        Care care = getCareById(careId);
+        careStateMachine.transition(role, care, CareStatus.COMPLETED);
+        Care savedCare = careRepository.save(care);
+        return careMapper.mapToDetailedCareDTO(savedCare, orSystemDefault);
     }
 
     private void assertNotReservationToYourself(String clientEmail, String caretakerEmail) {

--- a/src/main/java/com/example/petbuddybackend/service/care/CareService.java
+++ b/src/main/java/com/example/petbuddybackend/service/care/CareService.java
@@ -140,9 +140,9 @@ public class CareService {
         return careMapper.mapToDetailedCareDTO(care, timezone);
     }
 
-    public DetailedCareDTO markCareAsCompleted(Long careId, String name, Role role, ZoneId orSystemDefault) {
+    public DetailedCareDTO markCareAsConfirmed(Long careId, String name, Role role, ZoneId orSystemDefault) {
         Care care = getCareById(careId);
-        careStateMachine.transition(role, care, CareStatus.COMPLETED);
+        careStateMachine.transition(role, care, CareStatus.CONFIRMED);
         Care savedCare = careRepository.save(care);
         return careMapper.mapToDetailedCareDTO(savedCare, orSystemDefault);
     }

--- a/src/main/java/com/example/petbuddybackend/service/datageneration/MockService.java
+++ b/src/main/java/com/example/petbuddybackend/service/datageneration/MockService.java
@@ -555,8 +555,8 @@ public class MockService {
                 Pair.of(CareStatus.PENDING, CareStatus.PENDING),
                 Pair.of(CareStatus.PENDING, CareStatus.ACCEPTED),
                 Pair.of(CareStatus.ACCEPTED, CareStatus.PENDING),
-                Pair.of(CareStatus.AWAITING_PAYMENT, CareStatus.AWAITING_PAYMENT),
-                Pair.of(CareStatus.PAID, CareStatus.PAID),
+                Pair.of(CareStatus.READY_TO_PROCEED, CareStatus.READY_TO_PROCEED),
+                Pair.of(CareStatus.COMPLETED, CareStatus.COMPLETED),
                 Pair.of(CareStatus.OUTDATED, CareStatus.OUTDATED),
                 Pair.of(CareStatus.CANCELLED, CareStatus.CANCELLED)
         );

--- a/src/main/java/com/example/petbuddybackend/service/datageneration/MockService.java
+++ b/src/main/java/com/example/petbuddybackend/service/datageneration/MockService.java
@@ -556,7 +556,7 @@ public class MockService {
                 Pair.of(CareStatus.PENDING, CareStatus.ACCEPTED),
                 Pair.of(CareStatus.ACCEPTED, CareStatus.PENDING),
                 Pair.of(CareStatus.READY_TO_PROCEED, CareStatus.READY_TO_PROCEED),
-                Pair.of(CareStatus.COMPLETED, CareStatus.COMPLETED),
+                Pair.of(CareStatus.CONFIRMED, CareStatus.CONFIRMED),
                 Pair.of(CareStatus.OUTDATED, CareStatus.OUTDATED),
                 Pair.of(CareStatus.CANCELLED, CareStatus.CANCELLED)
         );

--- a/src/main/java/com/example/petbuddybackend/service/rating/RatingService.java
+++ b/src/main/java/com/example/petbuddybackend/service/rating/RatingService.java
@@ -6,6 +6,7 @@ import com.example.petbuddybackend.entity.care.CareStatus;
 import com.example.petbuddybackend.entity.rating.Rating;
 import com.example.petbuddybackend.repository.rating.RatingRepository;
 import com.example.petbuddybackend.service.care.CareService;
+import com.example.petbuddybackend.service.care.state.CareStateMachine;
 import com.example.petbuddybackend.service.mapper.RatingMapper;
 import com.example.petbuddybackend.service.user.UserService;
 import com.example.petbuddybackend.utils.exception.throweable.general.ForbiddenException;
@@ -28,6 +29,7 @@ public class RatingService {
     private final RatingRepository ratingRepository;
     private final CareService careService;
     private final UserService userService;
+    private final CareStateMachine careStateMachine;
     private final RatingMapper ratingMapper = RatingMapper.INSTANCE;
 
     public Page<RatingResponse> getRatings(Pageable pageable, String caretakerEmail) {
@@ -40,7 +42,7 @@ public class RatingService {
     public RatingResponse rateCaretaker(String clientEmail, Long careId, int rating, String comment) {
         Care care = careService.getCareById(careId);
         assertCareOfClient(care, clientEmail);
-        assertPaidState(care);
+        assertStatePermitsRating(care);
 
         Rating ratingEntity = createOrUpdateRating(clientEmail, careId, rating, comment);
         refreshRatingPhotos(ratingEntity);
@@ -63,7 +65,7 @@ public class RatingService {
 
         Care care = careService.getCareById(careId);
         assertCareOfClient(care, clientEmail);
-        assertPaidState(care);
+        assertStatePermitsRating(care);
 
         Rating ratingEntity = ratingRepository.findById(careId).orElseGet(() ->
                 Rating.builder()
@@ -84,16 +86,16 @@ public class RatingService {
         }
     }
 
-    private void assertPaidState(Care care) {
+    private void assertStatePermitsRating(Care care) {
         CareStatus caretakerStatus = care.getCaretakerStatus();
         CareStatus clientStatus = care.getClientStatus();
 
-        if(caretakerStatus != CareStatus.PAID || clientStatus != CareStatus.PAID) {
+        if(careStateMachine.canBeRated(care)) {
             throw new IllegalActionException(String.format(
                     CANNOT_RATE_CARE_STATUS_EXCEPTION,
                     care.getId(),
-                    CareStatus.PAID,
-                    CareStatus.PAID,
+                    CareStatus.COMPLETED,
+                    CareStatus.COMPLETED,
                     caretakerStatus,
                     clientStatus
             ));

--- a/src/main/java/com/example/petbuddybackend/service/rating/RatingService.java
+++ b/src/main/java/com/example/petbuddybackend/service/rating/RatingService.java
@@ -23,7 +23,7 @@ import org.springframework.transaction.annotation.Transactional;
 public class RatingService {
 
     private static final String RATING = "Rating";
-    private static final String CANNOT_RATE_CARE_STATUS_EXCEPTION = "Cannot rate care of id %d. Required statuses: %s %s, actual statuses: %s %s";
+    private static final String CANNOT_RATE_CARE_STATUS_EXCEPTION = "Cannot rate care of id %d of statuses: %s %s";
     private static final String NOT_CLIENT_MESSAGE = "User %s is not a client of care %d";
 
     private final RatingRepository ratingRepository;
@@ -90,12 +90,10 @@ public class RatingService {
         CareStatus caretakerStatus = care.getCaretakerStatus();
         CareStatus clientStatus = care.getClientStatus();
 
-        if(careStateMachine.canBeRated(care)) {
+        if(!careStateMachine.canBeRated(care)) {
             throw new IllegalActionException(String.format(
                     CANNOT_RATE_CARE_STATUS_EXCEPTION,
                     care.getId(),
-                    CareStatus.COMPLETED,
-                    CareStatus.COMPLETED,
                     caretakerStatus,
                     clientStatus
             ));

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -104,4 +104,4 @@ notification:
     rejected_reservation: "care_rejected"
 
 care:
-  accept-time-window: P0D        # 0 days, meaning the care must be accepted the day it has started
+  accept-time-window: P1D        # 2 days, meaning the care must be accepted within 2 days counting from the start date

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -102,3 +102,6 @@ notification:
     update_reservation: "care_update"
     accepted_reservation: "care_accepted"
     rejected_reservation: "care_rejected"
+
+care:
+  accept-time-window: P1D        # 1 day

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -104,4 +104,4 @@ notification:
     rejected_reservation: "care_rejected"
 
 care:
-  accept-time-window: P1D        # 1 day
+  accept-time-window: P0D        # 0 days, meaning the care must be accepted the day it has started

--- a/src/test/java/com/example/petbuddybackend/controller/CareControllerIntegrationTest.java
+++ b/src/test/java/com/example/petbuddybackend/controller/CareControllerIntegrationTest.java
@@ -271,6 +271,24 @@ public class CareControllerIntegrationTest {
 
     @Test
     @WithMockUser(username = CARETAKER_EMAIL)
+    void completeCareByCaretaker_ShouldReturnCompletedCare() throws Exception {
+        // Given
+        Care care = PersistenceUtils.addCare(careRepository, caretaker, client, animalRepository.findById("DOG").get());
+        care.setClientStatus(CareStatus.READY_TO_PROCEED);
+        care.setCaretakerStatus(CareStatus.READY_TO_PROCEED);
+        careRepository.saveAndFlush(care);
+
+        // When and Then
+        mockMvc.perform(post("/api/care/{careId}/complete", care.getId())
+                        .header(TIMEZONE_HEADER_NAME, "Europe/Warsaw")
+                        .header(ROLE_HEADER_NAME, Role.CARETAKER))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.clientStatus").value(CareStatus.COMPLETED.name()))
+                .andExpect(jsonPath("$.caretakerStatus").value(CareStatus.COMPLETED.name()));
+    }
+
+    @Test
+    @WithMockUser(username = CARETAKER_EMAIL)
     void acceptCareByCaretaker_ShouldReturnAcceptedCare() throws Exception {
         // Given
         PersistenceUtils.addCare(careRepository, caretaker, client, animalRepository.findById("DOG").get());
@@ -280,8 +298,8 @@ public class CareControllerIntegrationTest {
                         .header(TIMEZONE_HEADER_NAME, "Europe/Warsaw")
                         .header(ROLE_HEADER_NAME, Role.CARETAKER))
                 .andExpect(status().isOk())
-                .andExpect(jsonPath("$.clientStatus").value(CareStatus.AWAITING_PAYMENT.name()))
-                .andExpect(jsonPath("$.caretakerStatus").value(CareStatus.AWAITING_PAYMENT.name()));
+                .andExpect(jsonPath("$.clientStatus").value(CareStatus.READY_TO_PROCEED.name()))
+                .andExpect(jsonPath("$.caretakerStatus").value(CareStatus.READY_TO_PROCEED.name()));
     }
 
     @Test
@@ -313,7 +331,7 @@ public class CareControllerIntegrationTest {
     void acceptCareByCaretaker_WhenCaretakerStatusIsNotPending_ShouldThrowIllegalActionException() throws Exception {
         // Given
         Care care = PersistenceUtils.addCare(careRepository, caretaker, client, animalRepository.findById("DOG").get());
-        care.setCaretakerStatus(CareStatus.AWAITING_PAYMENT);
+        care.setCaretakerStatus(CareStatus.READY_TO_PROCEED);
         careRepository.save(care);
         // When and Then
         Long careId = careRepository.findAll().get(0).getId();

--- a/src/test/java/com/example/petbuddybackend/controller/CareControllerIntegrationTest.java
+++ b/src/test/java/com/example/petbuddybackend/controller/CareControllerIntegrationTest.java
@@ -276,6 +276,7 @@ public class CareControllerIntegrationTest {
         Care care = PersistenceUtils.addCare(careRepository, caretaker, client, animalRepository.findById("DOG").get());
         care.setClientStatus(CareStatus.READY_TO_PROCEED);
         care.setCaretakerStatus(CareStatus.READY_TO_PROCEED);
+        care.setCareStart(LocalDate.now());
         careRepository.saveAndFlush(care);
 
         // When and Then

--- a/src/test/java/com/example/petbuddybackend/controller/CareControllerIntegrationTest.java
+++ b/src/test/java/com/example/petbuddybackend/controller/CareControllerIntegrationTest.java
@@ -271,7 +271,7 @@ public class CareControllerIntegrationTest {
 
     @Test
     @WithMockUser(username = CARETAKER_EMAIL)
-    void completeCareByCaretaker_ShouldReturnCompletedCare() throws Exception {
+    void confirmCareByCaretaker_ShouldReturnConfirmCare() throws Exception {
         // Given
         Care care = PersistenceUtils.addCare(careRepository, caretaker, client, animalRepository.findById("DOG").get());
         care.setClientStatus(CareStatus.READY_TO_PROCEED);
@@ -280,12 +280,12 @@ public class CareControllerIntegrationTest {
         careRepository.saveAndFlush(care);
 
         // When and Then
-        mockMvc.perform(post("/api/care/{careId}/complete", care.getId())
+        mockMvc.perform(post("/api/care/{careId}/confirm", care.getId())
                         .header(TIMEZONE_HEADER_NAME, "Europe/Warsaw")
                         .header(ROLE_HEADER_NAME, Role.CARETAKER))
                 .andExpect(status().isOk())
-                .andExpect(jsonPath("$.clientStatus").value(CareStatus.COMPLETED.name()))
-                .andExpect(jsonPath("$.caretakerStatus").value(CareStatus.COMPLETED.name()));
+                .andExpect(jsonPath("$.clientStatus").value(CareStatus.CONFIRMED.name()))
+                .andExpect(jsonPath("$.caretakerStatus").value(CareStatus.CONFIRMED.name()));
     }
 
     @Test

--- a/src/test/java/com/example/petbuddybackend/scheduled/CareScheduledIntegrationTest.java
+++ b/src/test/java/com/example/petbuddybackend/scheduled/CareScheduledIntegrationTest.java
@@ -136,7 +136,7 @@ public class CareScheduledIntegrationTest {
     }
 
     @ParameterizedTest
-    @MethodSource("careStartTimeWithinAfter")
+    @MethodSource("careStartTimeAfterWindow")
     void terminateCares_dateAfterCompleteTimeWindow_shouldNotObsoleteCare(LocalDate startCare) {
         setupCaresWithCareStart(startCare);
 
@@ -179,14 +179,14 @@ public class CareScheduledIntegrationTest {
 
     static Stream<Arguments> careStartTimeWithinWindow() {
         return Stream.of(
-                Arguments.of(LocalDate.now()),
-                Arguments.of(LocalDate.now().minusDays(COMPLETE_WINDOW_DAYS /2)),
                 Arguments.of(LocalDate.now().minusDays(COMPLETE_WINDOW_DAYS)),
-                Arguments.of(LocalDate.now().plusDays(1))
+                Arguments.of(LocalDate.now().minusDays(COMPLETE_WINDOW_DAYS == 0 ? 1 : COMPLETE_WINDOW_DAYS / 2)),
+                Arguments.of(LocalDate.now().plusDays(1)),
+                Arguments.of(LocalDate.now())
         );
     }
 
-    static Stream<Arguments> careStartTimeWithinAfter() {
+    static Stream<Arguments> careStartTimeAfterWindow() {
         return Stream.of(
                 Arguments.of(LocalDate.now().minusDays(COMPLETE_WINDOW_DAYS + 1)),
                 Arguments.of(LocalDate.now().minusDays(COMPLETE_WINDOW_DAYS + 100))

--- a/src/test/java/com/example/petbuddybackend/scheduled/CareScheduledIntegrationTest.java
+++ b/src/test/java/com/example/petbuddybackend/scheduled/CareScheduledIntegrationTest.java
@@ -38,8 +38,8 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 @ContextConfiguration(classes = TestDataConfiguration.class)
 public class CareScheduledIntegrationTest {
 
-    private static final Duration COMPLETE_WINDOW;
-    private static final int COMPLETE_WINDOW_DAYS;
+    private static final Duration CONFIRM_WINDOW;
+    private static final int CONFIRM_WINDOW_DAYS;
 
     @Autowired
     private CareScheduled careScheduled;
@@ -67,8 +67,8 @@ public class CareScheduledIntegrationTest {
     private Caretaker caretaker;
 
     static {
-        COMPLETE_WINDOW_DAYS = 60;
-        COMPLETE_WINDOW = Duration.ofDays(COMPLETE_WINDOW_DAYS);
+        CONFIRM_WINDOW_DAYS = 60;
+        CONFIRM_WINDOW = Duration.ofDays(CONFIRM_WINDOW_DAYS);
     }
 
 
@@ -94,11 +94,11 @@ public class CareScheduledIntegrationTest {
                 Pair.of(CareStatus.READY_TO_PROCEED, CareStatus.READY_TO_PROCEED),
 
                 // CareStatuses to be kept
-                Pair.of(CareStatus.COMPLETED, CareStatus.COMPLETED),
+                Pair.of(CareStatus.CONFIRMED, CareStatus.CONFIRMED),
                 Pair.of(CareStatus.CANCELLED, CareStatus.CANCELLED)
         );
 
-        ReflectionTestUtils.setField(careStateMachine, "COMPLETE_CARE_TIME_WINDOW", COMPLETE_WINDOW);
+        ReflectionTestUtils.setField(careStateMachine, "CONFIRM_CARE_TIME_WINDOW", CONFIRM_WINDOW);
     }
 
     @AfterEach
@@ -110,7 +110,7 @@ public class CareScheduledIntegrationTest {
 
     @ParameterizedTest
     @MethodSource("careStartTimeWithinWindow")
-    void terminateCares_dateWithinCompleteTimeWindow_shouldNotObsoleteCare(LocalDate startCare) {
+    void terminateCares_dateWithinConfirmTimeWindow_shouldNotObsoleteCare(LocalDate startCare) {
         setupCaresWithCareStart(startCare);
 
         careScheduled.terminateCares();
@@ -122,7 +122,7 @@ public class CareScheduledIntegrationTest {
                 .toList();
 
         List<Care> paidCares = cares.stream()
-                .filter(care -> care.getClientStatus() == CareStatus.COMPLETED)
+                .filter(care -> care.getClientStatus() == CareStatus.CONFIRMED)
                 .toList();
 
         List<Care> cancelledCares = cares.stream()
@@ -137,7 +137,7 @@ public class CareScheduledIntegrationTest {
 
     @ParameterizedTest
     @MethodSource("careStartTimeAfterWindow")
-    void terminateCares_dateAfterCompleteTimeWindow_shouldNotObsoleteCare(LocalDate startCare) {
+    void terminateCares_dateAfterConfirmTimeWindow_shouldNotObsoleteCare(LocalDate startCare) {
         setupCaresWithCareStart(startCare);
 
         careScheduled.terminateCares();
@@ -149,7 +149,7 @@ public class CareScheduledIntegrationTest {
                 .toList();
 
         List<Care> paidCares = cares.stream()
-                .filter(care -> care.getClientStatus() == CareStatus.COMPLETED)
+                .filter(care -> care.getClientStatus() == CareStatus.CONFIRMED)
                 .toList();
 
         List<Care> cancelledCares = cares.stream()
@@ -157,7 +157,7 @@ public class CareScheduledIntegrationTest {
                 .toList();
 
         assertEquals(6, cares.size());
-        assertEquals(3, outdatedCares.size());
+        assertEquals(4, outdatedCares.size());
         assertEquals(1, paidCares.size());
         assertEquals(1, cancelledCares.size());
     }
@@ -179,8 +179,8 @@ public class CareScheduledIntegrationTest {
 
     static Stream<Arguments> careStartTimeWithinWindow() {
         return Stream.of(
-                Arguments.of(LocalDate.now().minusDays(COMPLETE_WINDOW_DAYS)),
-                Arguments.of(LocalDate.now().minusDays(COMPLETE_WINDOW_DAYS == 0 ? 1 : COMPLETE_WINDOW_DAYS / 2)),
+                Arguments.of(LocalDate.now().minusDays(CONFIRM_WINDOW_DAYS)),
+                Arguments.of(LocalDate.now().minusDays(CONFIRM_WINDOW_DAYS == 0 ? 1 : CONFIRM_WINDOW_DAYS / 2)),
                 Arguments.of(LocalDate.now().plusDays(1)),
                 Arguments.of(LocalDate.now())
         );
@@ -188,8 +188,8 @@ public class CareScheduledIntegrationTest {
 
     static Stream<Arguments> careStartTimeAfterWindow() {
         return Stream.of(
-                Arguments.of(LocalDate.now().minusDays(COMPLETE_WINDOW_DAYS + 1)),
-                Arguments.of(LocalDate.now().minusDays(COMPLETE_WINDOW_DAYS + 100))
+                Arguments.of(LocalDate.now().minusDays(CONFIRM_WINDOW_DAYS + 1)),
+                Arguments.of(LocalDate.now().minusDays(CONFIRM_WINDOW_DAYS + 100))
         );
     }
 }

--- a/src/test/java/com/example/petbuddybackend/scheduled/CareScheduledIntegrationTest.java
+++ b/src/test/java/com/example/petbuddybackend/scheduled/CareScheduledIntegrationTest.java
@@ -10,27 +10,36 @@ import com.example.petbuddybackend.repository.care.CareRepository;
 import com.example.petbuddybackend.repository.user.AppUserRepository;
 import com.example.petbuddybackend.repository.user.CaretakerRepository;
 import com.example.petbuddybackend.repository.user.ClientRepository;
+import com.example.petbuddybackend.service.care.state.CareStateMachine;
 import com.example.petbuddybackend.testconfig.TestDataConfiguration;
 import com.example.petbuddybackend.testutils.PersistenceUtils;
 import com.example.petbuddybackend.testutils.mock.MockCareProvider;
 import com.example.petbuddybackend.testutils.mock.MockUserProvider;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.data.util.Pair;
 import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.util.ReflectionTestUtils;
 
+import java.time.Duration;
 import java.time.LocalDate;
 import java.util.List;
 import java.util.Set;
+import java.util.stream.Stream;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 @SpringBootTest
 @ContextConfiguration(classes = TestDataConfiguration.class)
 public class CareScheduledIntegrationTest {
+
+    private static final Duration COMPLETE_WINDOW;
+    private static final int COMPLETE_WINDOW_DAYS;
 
     @Autowired
     private CareScheduled careScheduled;
@@ -48,11 +57,19 @@ public class CareScheduledIntegrationTest {
     private CaretakerRepository caretakerRepository;
 
     @Autowired
+    private CareStateMachine careStateMachine;
+
+    @Autowired
     private AnimalRepository animalRepository;
 
     private Set<Pair<CareStatus, CareStatus>> testStatuses;
     private Client client;
     private Caretaker caretaker;
+
+    static {
+        COMPLETE_WINDOW_DAYS = 60;
+        COMPLETE_WINDOW = Duration.ofDays(COMPLETE_WINDOW_DAYS);
+    }
 
 
     @BeforeEach
@@ -74,12 +91,14 @@ public class CareScheduledIntegrationTest {
                 Pair.of(CareStatus.PENDING, CareStatus.PENDING),
                 Pair.of(CareStatus.PENDING, CareStatus.ACCEPTED),
                 Pair.of(CareStatus.ACCEPTED, CareStatus.PENDING),
-                Pair.of(CareStatus.AWAITING_PAYMENT, CareStatus.AWAITING_PAYMENT),
+                Pair.of(CareStatus.READY_TO_PROCEED, CareStatus.READY_TO_PROCEED),
 
                 // CareStatuses to be kept
-                Pair.of(CareStatus.PAID, CareStatus.PAID),
+                Pair.of(CareStatus.COMPLETED, CareStatus.COMPLETED),
                 Pair.of(CareStatus.CANCELLED, CareStatus.CANCELLED)
         );
+
+        ReflectionTestUtils.setField(careStateMachine, "COMPLETE_CARE_TIME_WINDOW", COMPLETE_WINDOW);
     }
 
     @AfterEach
@@ -89,13 +108,11 @@ public class CareScheduledIntegrationTest {
         caretakerRepository.deleteAll();
     }
 
+    @ParameterizedTest
+    @MethodSource("careStartTimeWithinWindow")
+    void terminateCares_dateWithinCompleteTimeWindow_shouldNotObsoleteCare(LocalDate startCare) {
+        setupCaresWithCareStart(startCare);
 
-    @Test
-    void terminateCares_shouldTerminateProperCares() {
-        // Given
-        setupOutdatedCares();
-
-        // Then
         careScheduled.terminateCares();
 
         List<Care> cares = careRepository.findAll();
@@ -105,46 +122,47 @@ public class CareScheduledIntegrationTest {
                 .toList();
 
         List<Care> paidCares = cares.stream()
-                .filter(care -> care.getClientStatus() == CareStatus.PAID)
+                .filter(care -> care.getClientStatus() == CareStatus.COMPLETED)
                 .toList();
 
         List<Care> cancelledCares = cares.stream()
                 .filter(care -> care.getClientStatus() == CareStatus.CANCELLED)
                 .toList();
 
-        assertEquals(4, outdatedCares.size());
-        assertEquals(1, paidCares.size());
-        assertEquals(1, cancelledCares.size());
-    }
-
-    @Test
-    void terminateCares_shouldNotTerminateAnyNonOutdatedCare() {
-        // Given
-        setupNonOutdatedCares();
-
-        // Then
-        careScheduled.terminateCares();
-
-        List<Care> cares = careRepository.findAll();
-
-        List<Care> outdatedCares = cares.stream()
-                .filter(care -> care.getClientStatus() == CareStatus.OUTDATED)
-                .toList();
-
-        List<Care> paidCares = cares.stream()
-                .filter(care -> care.getClientStatus() == CareStatus.PAID)
-                .toList();
-
-        List<Care> cancelledCares = cares.stream()
-                .filter(care -> care.getClientStatus() == CareStatus.CANCELLED)
-                .toList();
-
+        assertEquals(6, cares.size());
         assertEquals(0, outdatedCares.size());
         assertEquals(1, paidCares.size());
         assertEquals(1, cancelledCares.size());
     }
 
-    private void setupOutdatedCares() {
+    @ParameterizedTest
+    @MethodSource("careStartTimeWithinAfter")
+    void terminateCares_dateAfterCompleteTimeWindow_shouldNotObsoleteCare(LocalDate startCare) {
+        setupCaresWithCareStart(startCare);
+
+        careScheduled.terminateCares();
+
+        List<Care> cares = careRepository.findAll();
+
+        List<Care> outdatedCares = cares.stream()
+                .filter(care -> care.getClientStatus() == CareStatus.OUTDATED)
+                .toList();
+
+        List<Care> paidCares = cares.stream()
+                .filter(care -> care.getClientStatus() == CareStatus.COMPLETED)
+                .toList();
+
+        List<Care> cancelledCares = cares.stream()
+                .filter(care -> care.getClientStatus() == CareStatus.CANCELLED)
+                .toList();
+
+        assertEquals(6, cares.size());
+        assertEquals(3, outdatedCares.size());
+        assertEquals(1, paidCares.size());
+        assertEquals(1, cancelledCares.size());
+    }
+
+    private void setupCaresWithCareStart(LocalDate careStart) {
         Animal animal = animalRepository.findById("DOG").get();
 
         testStatuses.stream()
@@ -152,24 +170,26 @@ public class CareScheduledIntegrationTest {
                         caretaker, client, animal, pair.getFirst(), pair.getSecond())
                 )
                 .map(care -> {
-                    care.setCareStart(LocalDate.now().minusDays(1));
+                    care.setCareStart(careStart);
                     return care;
                 })
                 .map(care -> PersistenceUtils.addCare(careRepository, care))
                 .toList();
     }
 
-    private void setupNonOutdatedCares() {
-        Animal animal = animalRepository.findById("DOG").get();
+    static Stream<Arguments> careStartTimeWithinWindow() {
+        return Stream.of(
+                Arguments.of(LocalDate.now()),
+                Arguments.of(LocalDate.now().minusDays(COMPLETE_WINDOW_DAYS /2)),
+                Arguments.of(LocalDate.now().minusDays(COMPLETE_WINDOW_DAYS)),
+                Arguments.of(LocalDate.now().plusDays(1))
+        );
+    }
 
-        testStatuses.stream()
-                .map(pair -> MockCareProvider.createMockCare(
-                        caretaker, client, animal, pair.getFirst(), pair.getSecond()))
-                .map(care -> {
-                    care.setCareStart(LocalDate.now().plusDays(1));
-                    return care;
-                })
-                .map(care -> PersistenceUtils.addCare(careRepository, care))
-                .toList();
+    static Stream<Arguments> careStartTimeWithinAfter() {
+        return Stream.of(
+                Arguments.of(LocalDate.now().minusDays(COMPLETE_WINDOW_DAYS + 1)),
+                Arguments.of(LocalDate.now().minusDays(COMPLETE_WINDOW_DAYS + 100))
+        );
     }
 }

--- a/src/test/java/com/example/petbuddybackend/service/care/CareServiceIntegrationTest.java
+++ b/src/test/java/com/example/petbuddybackend/service/care/CareServiceIntegrationTest.java
@@ -283,8 +283,8 @@ public class CareServiceIntegrationTest {
         // Then
         Care acceptedCare = careRepository.findById(result.id()).orElseThrow();
         assertNotNull(acceptedCare);
-        assertEquals(CareStatus.AWAITING_PAYMENT, acceptedCare.getCaretakerStatus());
-        assertEquals(CareStatus.AWAITING_PAYMENT, acceptedCare.getClientStatus());
+        assertEquals(CareStatus.READY_TO_PROCEED, acceptedCare.getCaretakerStatus());
+        assertEquals(CareStatus.READY_TO_PROCEED, acceptedCare.getClientStatus());
 
     }
 
@@ -637,7 +637,7 @@ public class CareServiceIntegrationTest {
                 ),
                 Arguments.of(
                         CareSearchCriteria.builder()
-                                .caretakerStatuses(Set.of(CareStatus.AWAITING_PAYMENT))
+                                .caretakerStatuses(Set.of(CareStatus.READY_TO_PROCEED))
                                 .build(),
                         Role.CARETAKER,
                         Set.of(),
@@ -646,7 +646,7 @@ public class CareServiceIntegrationTest {
                 ),
                 Arguments.of(
                         CareSearchCriteria.builder()
-                                .clientStatuses(Set.of(CareStatus.AWAITING_PAYMENT))
+                                .clientStatuses(Set.of(CareStatus.READY_TO_PROCEED))
                                 .build(),
                         Role.CARETAKER,
                         Set.of(),
@@ -762,8 +762,8 @@ public class CareServiceIntegrationTest {
                         LocalDate.of(2024, 5, 15),
                         LocalDate.of(2024, 5, 20),
                         new BigDecimal("10.00"),
-                        CareStatus.AWAITING_PAYMENT,
-                        CareStatus.AWAITING_PAYMENT
+                        CareStatus.READY_TO_PROCEED,
+                        CareStatus.READY_TO_PROCEED
                 ),
                 PersistenceUtils.addCare(
                         careRepository,

--- a/src/test/java/com/example/petbuddybackend/service/care/state/CareStateMachineTest.java
+++ b/src/test/java/com/example/petbuddybackend/service/care/state/CareStateMachineTest.java
@@ -1,0 +1,117 @@
+package com.example.petbuddybackend.service.care.state;
+
+import com.example.petbuddybackend.entity.care.Care;
+import com.example.petbuddybackend.entity.care.CareStatus;
+import com.example.petbuddybackend.entity.user.Role;
+import com.example.petbuddybackend.utils.exception.throweable.general.StateTransitionException;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import java.time.Duration;
+import java.time.LocalDate;
+import java.util.stream.Stream;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+@SpringBootTest
+public class CareStateMachineTest {
+
+    private static final Duration COMPLETE_WINDOW;
+    private static final int COMPLETE_WINDOW_DAYS;
+
+    @Autowired
+    private CareStateMachine careStateMachine;
+
+    static {
+        COMPLETE_WINDOW_DAYS = 60;
+        COMPLETE_WINDOW = Duration.ofDays(COMPLETE_WINDOW_DAYS);
+    }
+
+    @BeforeEach
+    void setup() {
+        ReflectionTestUtils.setField(careStateMachine, "COMPLETE_CARE_TIME_WINDOW", COMPLETE_WINDOW);
+    }
+
+    @Test
+    void transitionToEditCare_shouldSucceed() {
+        Care care = careOfStatuses(CareStatus.PENDING, CareStatus.PENDING);
+        careStateMachine.transitionToEditCare(care);
+    }
+
+    @Test
+    void transitionToEditCare_caretakerIsNotPending_shouldThrowException() {
+        Care care = careOfStatuses(CareStatus.PENDING, CareStatus.ACCEPTED);
+        assertThrows(StateTransitionException.class, () -> careStateMachine.transitionToEditCare(care));
+    }
+
+    @Test
+    void transitionToEditCare_clientIsNotPendingOrAccepted_shouldThrowException() {
+        Care care1 = careOfStatuses(CareStatus.READY_TO_PROCEED, CareStatus.PENDING);
+        assertThrows(StateTransitionException.class, () -> careStateMachine.transitionToEditCare(care1));
+
+        Care care2 = careOfStatuses(CareStatus.COMPLETED, CareStatus.PENDING);
+        assertThrows(StateTransitionException.class, () -> careStateMachine.transitionToEditCare(care2));
+    }
+
+    @Test
+    void transition_caretakerTransitionsToAccepted_shouldSucceed() {
+        Care care = careOfStatuses(CareStatus.ACCEPTED, CareStatus.PENDING);
+        Care updatedCare = careStateMachine.transition(Role.CARETAKER, care, CareStatus.ACCEPTED);
+        assertEquals(CareStatus.READY_TO_PROCEED, updatedCare.getCaretakerStatus());
+    }
+
+    @Test
+    void transition_caretakerTransitionsToAccepted_clientNotAccepted_shouldThrow() {
+        Care care = careOfStatuses(CareStatus.PENDING, CareStatus.PENDING);
+        assertThrows(StateTransitionException.class, () -> careStateMachine.transition(Role.CARETAKER, care, CareStatus.ACCEPTED));
+    }
+
+    @ParameterizedTest
+    @MethodSource("provideValidCareStartDates")
+    void transition_caretakerMarksCareAsCompleted_shouldSucceed(LocalDate startCareDate) {
+        Care care = careOfStatuses(CareStatus.READY_TO_PROCEED, CareStatus.READY_TO_PROCEED, startCareDate);
+        careStateMachine.transition(Role.CARETAKER, care, CareStatus.COMPLETED);
+    }
+
+    @ParameterizedTest
+    @MethodSource("provideInvalidCareStartDates")
+    void transition_caretakerMarksCareAsCompleted_invalidStartDate_shouldThrow(LocalDate startCareDate) {
+        Care care = careOfStatuses(CareStatus.READY_TO_PROCEED, CareStatus.READY_TO_PROCEED, startCareDate);
+
+        assertThrows(StateTransitionException.class,
+                () -> careStateMachine.transition(Role.CARETAKER, care, CareStatus.COMPLETED));
+    }
+
+    private Care careOfStatuses(CareStatus clientStatus, CareStatus caretakerStatus, LocalDate careStart) {
+        return Care.builder()
+                .clientStatus(clientStatus)
+                .caretakerStatus(caretakerStatus)
+                .careStart(careStart)
+                .build();
+    }
+
+    private Care careOfStatuses(CareStatus clientStatus, CareStatus caretakerStatus) {
+        return careOfStatuses(clientStatus, caretakerStatus, LocalDate.now());
+    }
+
+    private static Stream<LocalDate> provideValidCareStartDates() {
+        return Stream.of(
+                LocalDate.now().minusDays(COMPLETE_WINDOW_DAYS),
+                LocalDate.now().minusDays(COMPLETE_WINDOW_DAYS-1),
+                LocalDate.now()
+        );
+    }
+
+    private static Stream<LocalDate> provideInvalidCareStartDates() {
+        return Stream.of(
+                LocalDate.now().minusDays(COMPLETE_WINDOW_DAYS+1),
+                LocalDate.now().plusDays(1)
+        );
+    }
+}

--- a/src/test/java/com/example/petbuddybackend/service/care/state/CareStateMachineTest.java
+++ b/src/test/java/com/example/petbuddybackend/service/care/state/CareStateMachineTest.java
@@ -22,20 +22,20 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 @SpringBootTest
 public class CareStateMachineTest {
 
-    private static final Duration COMPLETE_WINDOW;
-    private static final int COMPLETE_WINDOW_DAYS;
+    private static final Duration CONFIRM_WINDOW;
+    private static final int CONFIRM_WINDOW_DAYS;
 
     @Autowired
     private CareStateMachine careStateMachine;
 
     static {
-        COMPLETE_WINDOW_DAYS = 60;
-        COMPLETE_WINDOW = Duration.ofDays(COMPLETE_WINDOW_DAYS);
+        CONFIRM_WINDOW_DAYS = 60;
+        CONFIRM_WINDOW = Duration.ofDays(CONFIRM_WINDOW_DAYS);
     }
 
     @BeforeEach
     void setup() {
-        ReflectionTestUtils.setField(careStateMachine, "COMPLETE_CARE_TIME_WINDOW", COMPLETE_WINDOW);
+        ReflectionTestUtils.setField(careStateMachine, "CONFIRM_CARE_TIME_WINDOW", CONFIRM_WINDOW);
     }
 
     @Test
@@ -55,7 +55,7 @@ public class CareStateMachineTest {
         Care care1 = careOfStatuses(CareStatus.READY_TO_PROCEED, CareStatus.PENDING);
         assertThrows(StateTransitionException.class, () -> careStateMachine.transitionToEditCare(care1));
 
-        Care care2 = careOfStatuses(CareStatus.COMPLETED, CareStatus.PENDING);
+        Care care2 = careOfStatuses(CareStatus.CONFIRMED, CareStatus.PENDING);
         assertThrows(StateTransitionException.class, () -> careStateMachine.transitionToEditCare(care2));
     }
 
@@ -74,18 +74,18 @@ public class CareStateMachineTest {
 
     @ParameterizedTest
     @MethodSource("provideValidCareStartDates")
-    void transition_caretakerMarksCareAsCompleted_shouldSucceed(LocalDate startCareDate) {
+    void transition_caretakerMarksCareAsConfirmed_shouldSucceed(LocalDate startCareDate) {
         Care care = careOfStatuses(CareStatus.READY_TO_PROCEED, CareStatus.READY_TO_PROCEED, startCareDate);
-        careStateMachine.transition(Role.CARETAKER, care, CareStatus.COMPLETED);
+        careStateMachine.transition(Role.CARETAKER, care, CareStatus.CONFIRMED);
     }
 
     @ParameterizedTest
     @MethodSource("provideInvalidCareStartDates")
-    void transition_caretakerMarksCareAsCompleted_invalidStartDate_shouldThrow(LocalDate startCareDate) {
+    void transition_caretakerMarksCareAsConfirmed_invalidStartDate_shouldThrow(LocalDate startCareDate) {
         Care care = careOfStatuses(CareStatus.READY_TO_PROCEED, CareStatus.READY_TO_PROCEED, startCareDate);
 
         assertThrows(StateTransitionException.class,
-                () -> careStateMachine.transition(Role.CARETAKER, care, CareStatus.COMPLETED));
+                () -> careStateMachine.transition(Role.CARETAKER, care, CareStatus.CONFIRMED));
     }
 
     private Care careOfStatuses(CareStatus clientStatus, CareStatus caretakerStatus, LocalDate careStart) {
@@ -102,15 +102,15 @@ public class CareStateMachineTest {
 
     private static Stream<LocalDate> provideValidCareStartDates() {
         return Stream.of(
-                LocalDate.now().minusDays(COMPLETE_WINDOW_DAYS),
-                LocalDate.now().minusDays(COMPLETE_WINDOW_DAYS-1),
+                LocalDate.now().minusDays(CONFIRM_WINDOW_DAYS),
+                LocalDate.now().minusDays(CONFIRM_WINDOW_DAYS -1),
                 LocalDate.now()
         );
     }
 
     private static Stream<LocalDate> provideInvalidCareStartDates() {
         return Stream.of(
-                LocalDate.now().minusDays(COMPLETE_WINDOW_DAYS+1),
+                LocalDate.now().minusDays(CONFIRM_WINDOW_DAYS +1),
                 LocalDate.now().plusDays(1)
         );
     }

--- a/src/test/java/com/example/petbuddybackend/service/rating/RatingServiceTest.java
+++ b/src/test/java/com/example/petbuddybackend/service/rating/RatingServiceTest.java
@@ -38,7 +38,7 @@ import java.util.Set;
 import java.util.stream.Stream;
 
 import static com.example.petbuddybackend.testutils.mock.MockCareProvider.createMockCare;
-import static com.example.petbuddybackend.testutils.mock.MockCareProvider.createMockCompletedCare;
+import static com.example.petbuddybackend.testutils.mock.MockCareProvider.createMockConfirmedCare;
 import static com.example.petbuddybackend.testutils.mock.MockRatingProvider.createMockRating;
 import static com.example.petbuddybackend.testutils.mock.MockUserProvider.createMockClient;
 import static org.junit.jupiter.api.Assertions.*;
@@ -86,7 +86,7 @@ public class RatingServiceTest {
                 careRepository, createMockCare(caretaker, client, animalRepository.findById("DOG").orElseThrow())
         );
         paidCare = PersistenceUtils.addCare(
-                careRepository, createMockCompletedCare(caretaker, client, animalRepository.findById("DOG").orElseThrow())
+                careRepository, createMockConfirmedCare(caretaker, client, animalRepository.findById("DOG").orElseThrow())
         );
     }
 

--- a/src/test/java/com/example/petbuddybackend/service/rating/RatingServiceTest.java
+++ b/src/test/java/com/example/petbuddybackend/service/rating/RatingServiceTest.java
@@ -38,7 +38,7 @@ import java.util.Set;
 import java.util.stream.Stream;
 
 import static com.example.petbuddybackend.testutils.mock.MockCareProvider.createMockCare;
-import static com.example.petbuddybackend.testutils.mock.MockCareProvider.createMockPaidCare;
+import static com.example.petbuddybackend.testutils.mock.MockCareProvider.createMockCompletedCare;
 import static com.example.petbuddybackend.testutils.mock.MockRatingProvider.createMockRating;
 import static com.example.petbuddybackend.testutils.mock.MockUserProvider.createMockClient;
 import static org.junit.jupiter.api.Assertions.*;
@@ -86,7 +86,7 @@ public class RatingServiceTest {
                 careRepository, createMockCare(caretaker, client, animalRepository.findById("DOG").orElseThrow())
         );
         paidCare = PersistenceUtils.addCare(
-                careRepository, createMockPaidCare(caretaker, client, animalRepository.findById("DOG").orElseThrow())
+                careRepository, createMockCompletedCare(caretaker, client, animalRepository.findById("DOG").orElseThrow())
         );
     }
 

--- a/src/test/java/com/example/petbuddybackend/testutils/mock/MockCareProvider.java
+++ b/src/test/java/com/example/petbuddybackend/testutils/mock/MockCareProvider.java
@@ -41,11 +41,11 @@ public class MockCareProvider {
         return createMockCare(caretaker, client, animal, CareStatus.ACCEPTED, CareStatus.PENDING);
     }
 
-    public static Care createMockCompletedCare(Caretaker caretaker, Client client, Animal animal) {
+    public static Care createMockConfirmedCare(Caretaker caretaker, Client client, Animal animal) {
 
         return Care.builder()
-                .caretakerStatus(CareStatus.COMPLETED)
-                .clientStatus(CareStatus.COMPLETED)
+                .caretakerStatus(CareStatus.CONFIRMED)
+                .clientStatus(CareStatus.CONFIRMED)
                 .careStart(LocalDate.now().plusDays(2))
                 .careEnd(LocalDate.now().plusDays(7))
                 .description("Test care description")

--- a/src/test/java/com/example/petbuddybackend/testutils/mock/MockCareProvider.java
+++ b/src/test/java/com/example/petbuddybackend/testutils/mock/MockCareProvider.java
@@ -41,11 +41,11 @@ public class MockCareProvider {
         return createMockCare(caretaker, client, animal, CareStatus.ACCEPTED, CareStatus.PENDING);
     }
 
-    public static Care createMockPaidCare(Caretaker caretaker, Client client, Animal animal) {
+    public static Care createMockCompletedCare(Caretaker caretaker, Client client, Animal animal) {
 
         return Care.builder()
-                .caretakerStatus(CareStatus.PAID)
-                .clientStatus(CareStatus.PAID)
+                .caretakerStatus(CareStatus.COMPLETED)
+                .clientStatus(CareStatus.COMPLETED)
                 .careStart(LocalDate.now().plusDays(2))
                 .careEnd(LocalDate.now().plusDays(7))
                 .description("Test care description")

--- a/src/test/resources/application.yml
+++ b/src/test/resources/application.yml
@@ -86,3 +86,6 @@ notification:
     update_reservation: "care_update"
     accepted_reservation: "care_accepted"
     rejected_reservation: "care_rejected"
+
+care:
+  accept-time-window: P10D        # 10 days


### PR DESCRIPTION
- dodanie endpointu dla opiekuna do oznaczenia opieki jako wykonana
- trzeba teraz oznaczyć opiekę jako wykonaną w dniu rozpoczęcia opieki
- jeżeli po dniu rozpoczęcia opieki nie zostanie ona oznaczona jako rozpoczęta, to oznaczana jest jako `OUTDATED`