### PR TITLE
Cyndzer/ZPI-4-ZPI-66-BE-95-BE-96 Zdjęcie profilowe w czacie

### DIFF
--- a/petbuddy_code_style.xml
+++ b/petbuddy_code_style.xml
@@ -1,0 +1,11 @@
+<code_scheme name="petbuddy-code-style" version="173">
+  <codeStyleSettings language="JAVA">
+    <option name="KEEP_LINE_BREAKS" value="false" />
+    <option name="CALL_PARAMETERS_WRAP" value="5" />
+    <option name="CALL_PARAMETERS_LPAREN_ON_NEXT_LINE" value="true" />
+    <option name="CALL_PARAMETERS_RPAREN_ON_NEXT_LINE" value="true" />
+    <option name="METHOD_PARAMETERS_WRAP" value="5" />
+    <option name="WRAP_LONG_LINES" value="true" />
+    <option name="WRAP_ON_TYPING" value="1" />
+  </codeStyleSettings>
+</code_scheme>

--- a/src/main/java/com/example/petbuddybackend/config/datageneration/MockDataCreator.java
+++ b/src/main/java/com/example/petbuddybackend/config/datageneration/MockDataCreator.java
@@ -37,8 +37,10 @@ import com.example.petbuddybackend.service.datageneration.MockService;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.context.annotation.Profile;
+import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Propagation;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.math.BigDecimal;
@@ -186,10 +188,10 @@ public class MockDataCreator {
                 careRepository.count() != 0;
     }
 
-    private void createKnownMockUsers() {
+    public void createKnownMockUsers() {
         Client client = createKnownClient();
         Caretaker caretaker = createKnownCaretaker();
-        createChat(client, caretaker);
+
         Care care = careRepository.saveAndFlush(mockService.createMockCare(
                 client,
                 caretaker,
@@ -206,6 +208,18 @@ public class MockDataCreator {
                         .care(care)
                         .build()
         );
+
+        ChatRoom knownUsersChatRoom = createChat(client, caretaker);
+
+        createChat(client, caretakers.get(1));
+
+//        chatService.createMessage(
+//                knownUsersChatRoom,
+//                caretaker.getEmail(),
+//                Role.CARETAKER,
+//                new ChatMessageSent("Message after other chats"),
+//                false
+//        );
     }
 
     private List<Rating> addRatingsToSliceOfCaretakers(List<Caretaker> allCaretakers) {
@@ -263,7 +277,8 @@ public class MockDataCreator {
         return caretakerRepository.save(caretaker);
     }
 
-    private void createChat(Client client, Caretaker caretaker) {
+    @Transactional(propagation = Propagation.REQUIRES_NEW)
+    public ChatRoom createChat(Client client, Caretaker caretaker) {
         chatService.createChatRoomWithMessage(
                 client.getEmail(),
                 Role.CLIENT,
@@ -272,13 +287,14 @@ public class MockDataCreator {
                 ZoneId.systemDefault()
         );
 
-        ChatRoomDTO createdChatRoomDTO = chatService.getChatRoomsByParticipantEmail(
+        Page<ChatRoomDTO> chatRooms = chatService.getChatRoomsByParticipantEmailSortedByLastMessage(
                 client.getEmail(),
                 Role.CLIENT,
                 PageRequest.of(0, 1),
                 ZoneId.systemDefault()
-        ).stream().findFirst().orElseThrow();
+        );
 
+        ChatRoomDTO createdChatRoomDTO = chatRooms.getContent().get(0);
         ChatRoom chatRoom = chatRoomRepository.findById(createdChatRoomDTO.getId()).orElseThrow();
 
         for (int i = 0; i < 10; i++) {
@@ -299,5 +315,7 @@ public class MockDataCreator {
                     false
             );
         }
+
+        return chatRoom;
     }
 }

--- a/src/main/java/com/example/petbuddybackend/config/datageneration/MockDataCreator.java
+++ b/src/main/java/com/example/petbuddybackend/config/datageneration/MockDataCreator.java
@@ -209,17 +209,8 @@ public class MockDataCreator {
                         .build()
         );
 
-        ChatRoom knownUsersChatRoom = createChat(client, caretaker);
-
+        createChat(client, caretaker);
         createChat(client, caretakers.get(1));
-
-//        chatService.createMessage(
-//                knownUsersChatRoom,
-//                caretaker.getEmail(),
-//                Role.CARETAKER,
-//                new ChatMessageSent("Message after other chats"),
-//                false
-//        );
     }
 
     private List<Rating> addRatingsToSliceOfCaretakers(List<Caretaker> allCaretakers) {

--- a/src/main/java/com/example/petbuddybackend/config/datageneration/MockDataCreator.java
+++ b/src/main/java/com/example/petbuddybackend/config/datageneration/MockDataCreator.java
@@ -188,7 +188,7 @@ public class MockDataCreator {
                 careRepository.count() != 0;
     }
 
-    public void createKnownMockUsers() {
+    private void createKnownMockUsers() {
         Client client = createKnownClient();
         Caretaker caretaker = createKnownCaretaker();
 

--- a/src/main/java/com/example/petbuddybackend/controller/ChatController.java
+++ b/src/main/java/com/example/petbuddybackend/controller/ChatController.java
@@ -135,7 +135,8 @@ public class ChatController {
             summary = "Get all chat rooms",
             description = """
                         Retrieves a paginated list of chat rooms where the user is a participant. Useful for connecting
-                        to existing chat room via websocket.
+                        to existing chat room via websocket. The chat rooms are sorted by the date of last message in
+                        chat.
                         """
     )
     public Page<ChatRoomDTO> getChatRooms(
@@ -145,7 +146,7 @@ public class ChatController {
             @TimeZoneParameter @RequestHeader(value = "${header-name.timezone}", required = false) String acceptTimeZone
     ) {
         Pageable pageable = PagingUtils.createPageable(pagingParams);
-        return chatService.getChatRoomsByParticipantEmail(
+        return chatService.getChatRoomsByParticipantEmailSortedByLastMessage(
                 principal.getName(),
                 acceptRole,
                 pageable,

--- a/src/main/java/com/example/petbuddybackend/controller/websocket/ChatWebSocketController.java
+++ b/src/main/java/com/example/petbuddybackend/controller/websocket/ChatWebSocketController.java
@@ -79,12 +79,10 @@ public class ChatWebSocketController {
 
         wsChatMessageSender.sendMessages(chatRoom, new ChatNotificationMessage(messageDTO));
 
-        if(!seenByRecipient) {
-            wsNotificationSender.sendNotification(
-                    recipientUsername,
-                    chatService.getUnseenChatsNumberNotification(recipientUsername)
-            );
-        }
+        wsNotificationSender.sendNotification(
+                recipientUsername,
+                chatService.getUnseenChatsNumberNotification(recipientUsername)
+        );
 
         wsNotificationSender.sendNotification(
                 principalUsername,

--- a/src/main/java/com/example/petbuddybackend/controller/websocket/ChatWebSocketController.java
+++ b/src/main/java/com/example/petbuddybackend/controller/websocket/ChatWebSocketController.java
@@ -85,6 +85,11 @@ public class ChatWebSocketController {
                     chatService.getUnseenChatsNumberNotification(recipientUsername)
             );
         }
+
+        wsNotificationSender.sendNotification(
+                principalUsername,
+                chatService.getUnseenChatsNumberNotification(principalUsername)
+        );
     }
 
     @EventListener

--- a/src/main/java/com/example/petbuddybackend/dto/chat/ChatRoomDTO.java
+++ b/src/main/java/com/example/petbuddybackend/dto/chat/ChatRoomDTO.java
@@ -1,13 +1,10 @@
 package com.example.petbuddybackend.dto.chat;
 
-import com.example.petbuddybackend.utils.time.TimeUtils;
-import com.fasterxml.jackson.annotation.JsonFormat;
+import com.example.petbuddybackend.dto.user.AccountDataDTO;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
 import lombok.NoArgsConstructor;
-
-import java.time.ZonedDateTime;
 
 @Data
 @Builder
@@ -15,12 +12,6 @@ import java.time.ZonedDateTime;
 @AllArgsConstructor
 public class ChatRoomDTO {
     private Long id;
-    private String chatterEmail;
-    private String chatterName;
-    private String chatterSurname;
-    @JsonFormat(pattern = TimeUtils.ZONED_DATETIME_FORMAT)
-    private ZonedDateTime lastMessageCreatedAt;
-    private String lastMessage;
-    private String lastMessageSendBy;
-    private Boolean seenByPrincipal;
+    private AccountDataDTO chatter;
+    private ChatMessageDTO lastMessage;
 }

--- a/src/main/java/com/example/petbuddybackend/entity/chat/ChatMessage.java
+++ b/src/main/java/com/example/petbuddybackend/entity/chat/ChatMessage.java
@@ -7,7 +7,7 @@ import lombok.*;
 import java.time.ZonedDateTime;
 
 @Entity
-@Table(indexes = @Index(name = "chatRoomCreatedAtIndex", columnList = "chatRoom, createdAt DESC"))
+@Table(indexes = @Index(name = "chatRoomCreatedAtIndex", columnList = "chat_room_id, createdAt DESC"))
 @Builder
 @Getter @Setter
 @NoArgsConstructor

--- a/src/main/java/com/example/petbuddybackend/entity/chat/ChatMessage.java
+++ b/src/main/java/com/example/petbuddybackend/entity/chat/ChatMessage.java
@@ -6,8 +6,9 @@ import lombok.*;
 
 import java.time.ZonedDateTime;
 
-@Builder
 @Entity
+@Table(indexes = @Index(name = "chatRoomCreatedAtIndex", columnList = "chatRoom, createdAt DESC"))
+@Builder
 @Getter @Setter
 @NoArgsConstructor
 @AllArgsConstructor

--- a/src/main/java/com/example/petbuddybackend/entity/chat/ChatRoom.java
+++ b/src/main/java/com/example/petbuddybackend/entity/chat/ChatRoom.java
@@ -33,7 +33,7 @@ public class ChatRoom {
     @JoinColumn(name = "caretakerEmail", referencedColumnName = "email")
     private Caretaker caretaker;
 
-    @OneToMany(mappedBy = "chatRoom", cascade = CascadeType.ALL, fetch = FetchType.LAZY, orphanRemoval = true)
+    @OneToMany(mappedBy = "chatRoom", cascade = CascadeType.ALL, fetch = FetchType.LAZY)
     @Builder.Default
     private List<ChatMessage> messages = new ArrayList<>();
 }

--- a/src/main/java/com/example/petbuddybackend/entity/chat/ChatRoom.java
+++ b/src/main/java/com/example/petbuddybackend/entity/chat/ChatRoom.java
@@ -6,6 +6,7 @@ import jakarta.persistence.*;
 import lombok.*;
 import org.hibernate.annotations.Check;
 
+import java.util.ArrayList;
 import java.util.List;
 
 @Entity
@@ -33,5 +34,6 @@ public class ChatRoom {
     private Caretaker caretaker;
 
     @OneToMany(mappedBy = "chatRoom", cascade = CascadeType.ALL, fetch = FetchType.LAZY, orphanRemoval = true)
-    private List<ChatMessage> messages;
+    @Builder.Default
+    private List<ChatMessage> messages = new ArrayList<>();
 }

--- a/src/main/java/com/example/petbuddybackend/repository/chat/ChatMessageRepository.java
+++ b/src/main/java/com/example/petbuddybackend/repository/chat/ChatMessageRepository.java
@@ -15,13 +15,11 @@ public interface ChatMessageRepository extends JpaRepository<ChatMessage, Long> 
     @Modifying
     @Transactional
     @Query("""
-    
         UPDATE ChatMessage m
         SET m.seenByRecipient = true
         WHERE m.chatRoom.id = :chatRoomId
           AND m.seenByRecipient = false
           AND m.sender.email != :userEmail
-        
     """)
     void updateUnseenMessagesOfUser(Long chatRoomId, String userEmail);
 
@@ -36,4 +34,30 @@ public interface ChatMessageRepository extends JpaRepository<ChatMessage, Long> 
     void updateMessagesSeenOfBothUsers(Long chatRoomId);
 
     ChatMessage findFirstByChatRoom_IdOrderByCreatedAtDesc(Long chatRoomId);
+
+    @Query("""
+        SELECT cm
+        FROM ChatMessage cm
+        WHERE cm.chatRoom.client.email = :clientUsername
+            AND cm.createdAt = (
+                SELECT MAX(cm2.createdAt)
+                FROM ChatMessage cm2
+                WHERE cm2.chatRoom = cm.chatRoom
+            )
+        ORDER BY cm.createdAt DESC
+    """)
+    Page<ChatMessage> findLastMessagesOfChatRoomsOfClient(String clientUsername, Pageable pageable);
+
+    @Query("""
+        SELECT cm
+        FROM ChatMessage cm
+        WHERE cm.chatRoom.caretaker.email = :caretakerUsername
+            AND cm.createdAt = (
+                SELECT MAX(cm2.createdAt)
+                FROM ChatMessage cm2
+                WHERE cm2.chatRoom = cm.chatRoom
+            )
+        ORDER BY cm.createdAt DESC
+    """)
+    Page<ChatMessage> findLastMessagesOfChatRoomsOfCaretaker(String caretakerUsername, Pageable pageable);
 }

--- a/src/main/java/com/example/petbuddybackend/repository/chat/ChatRoomRepository.java
+++ b/src/main/java/com/example/petbuddybackend/repository/chat/ChatRoomRepository.java
@@ -1,8 +1,6 @@
 package com.example.petbuddybackend.repository.chat;
 
 import com.example.petbuddybackend.entity.chat.ChatRoom;
-import org.springframework.data.domain.Page;
-import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 
@@ -46,24 +44,4 @@ public interface ChatRoomRepository extends JpaRepository<ChatRoom, Long> {
         )
     """)
     Integer countUnreadChatsForUserAsCaretaker(String userEmail);
-
-    @Query("""
-        SELECT cr
-        FROM ChatRoom cr
-        JOIN cr.messages cm
-        WHERE cr.caretaker.email = :email
-        GROUP BY cr
-        ORDER BY MAX(cm.createdAt) DESC
-    """)
-    Page<ChatRoom> findByCaretakerEmailOrderByLastMessageDesc(String email, Pageable pageable);
-
-    @Query("""
-        SELECT cr
-        FROM ChatRoom cr
-        JOIN cr.messages cm
-        WHERE cr.client.email = :email
-        GROUP BY cr
-        ORDER BY MAX(cm.createdAt) DESC
-    """)
-    Page<ChatRoom> findByClientEmailOrderByLastMessageDesc(String email, Pageable pageable);
 }

--- a/src/main/java/com/example/petbuddybackend/repository/chat/ChatRoomRepository.java
+++ b/src/main/java/com/example/petbuddybackend/repository/chat/ChatRoomRepository.java
@@ -1,6 +1,5 @@
 package com.example.petbuddybackend.repository.chat;
 
-import com.example.petbuddybackend.dto.chat.ChatRoomDTO;
 import com.example.petbuddybackend.entity.chat.ChatRoom;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
@@ -19,58 +18,6 @@ public interface ChatRoomRepository extends JpaRepository<ChatRoom, Long> {
     boolean existsByClient_EmailAndCaretaker_Email(String clientEmail, String caretakerEmail);
 
     Optional<ChatRoom> findByClient_EmailAndCaretaker_Email(String clientEmail, String caretakerEmail);
-
-    @Query("""
-        SELECT new com.example.petbuddybackend.dto.chat.ChatRoomDTO(
-               cr.id,
-               cr.caretaker.email,
-               cr.caretaker.accountData.name,
-               cr.caretaker.accountData.surname,
-               cm.createdAt,
-               cm.content,
-               cm.sender.email,
-               CASE WHEN cm.sender.email = cr.client.email THEN true ELSE cm.seenByRecipient END
-        )
-        FROM ChatRoom cr
-        JOIN ChatMessage cm ON cm.chatRoom.id = cr.id
-        WHERE cr.client.email = :email
-        AND cm.id = (
-            SELECT MIN(cm2.id)
-            FROM ChatMessage cm2
-            WHERE cm2.createdAt = (
-                SELECT MAX(cm3.createdAt)
-                FROM ChatMessage cm3
-                WHERE cm3.chatRoom.id = cr.id
-            ) AND cm2.chatRoom.id = cr.id
-        )
-        """)
-    Page<ChatRoomDTO> findByClientEmailSortByLastMessageDesc(String email, Pageable pageable);
-
-    @Query("""
-        SELECT new com.example.petbuddybackend.dto.chat.ChatRoomDTO(
-               cr.id,
-               cr.client.email,
-               cr.client.accountData.name,
-               cr.client.accountData.surname,
-               cm.createdAt,
-               cm.content,
-               cm.sender.email,
-               CASE WHEN cm.sender.email = cr.caretaker.email THEN true ELSE cm.seenByRecipient END
-        )
-        FROM ChatRoom cr
-        JOIN ChatMessage cm ON cm.chatRoom.id = cr.id
-        WHERE cr.caretaker.email = :email
-        AND cm.id = (
-            SELECT MIN(cm2.id)
-            FROM ChatMessage cm2
-            WHERE cm2.createdAt = (
-                SELECT MAX(cm3.createdAt)
-                FROM ChatMessage cm3
-                WHERE cm3.chatRoom.id = cr.id
-            ) AND cm2.chatRoom.id = cr.id
-        )
-        """)
-    Page<ChatRoomDTO> findByCaretakerEmailSortByLastMessageDesc(String email, Pageable pageable);
 
     @Query("""
         SELECT COUNT(cr)
@@ -100,4 +47,23 @@ public interface ChatRoomRepository extends JpaRepository<ChatRoom, Long> {
     """)
     Integer countUnreadChatsForUserAsCaretaker(String userEmail);
 
+    @Query("""
+        SELECT cr
+        FROM ChatRoom cr
+        JOIN cr.messages cm
+        WHERE cr.caretaker.email = :email
+        GROUP BY cr
+        ORDER BY MAX(cm.createdAt) DESC
+    """)
+    Page<ChatRoom> findByCaretakerEmailOrderByLastMessageDesc(String email, Pageable pageable);
+
+    @Query("""
+        SELECT cr
+        FROM ChatRoom cr
+        JOIN cr.messages cm
+        WHERE cr.client.email = :email
+        GROUP BY cr
+        ORDER BY MAX(cm.createdAt) DESC
+    """)
+    Page<ChatRoom> findByClientEmailOrderByLastMessageDesc(String email, Pageable pageable);
 }

--- a/src/main/java/com/example/petbuddybackend/service/chat/ChatService.java
+++ b/src/main/java/com/example/petbuddybackend/service/chat/ChatService.java
@@ -60,6 +60,18 @@ public class ChatService {
                 .map(message -> chatMapper.mapToChatMessageDTO(message, timeZone));
     }
 
+    @Transactional(readOnly = true)
+    public Page<ChatRoomDTO> getChatRoomsByParticipantEmailSortedByLastMessage(String principalEmail,
+                                                                               Role role,
+                                                                               Pageable pageable,
+                                                                               ZoneId timeZone) {
+        Page<ChatRoom> principalChatRooms = role == Role.CLIENT ?
+                chatRoomRepository.findByClientEmailOrderByLastMessageDesc(principalEmail, pageable) :
+                chatRoomRepository.findByCaretakerEmailOrderByLastMessageDesc(principalEmail, pageable);
+
+        return principalChatRooms.map(room -> mapToChatRoomDTO(principalEmail, room, timeZone));
+    }
+
     public ChatRoom getChatRoomById(Long chatId) {
         return chatRepository.findById(chatId).orElseThrow(() ->
                 NotFoundException.withFormattedMessage(CHAT, chatId.toString())
@@ -76,17 +88,6 @@ public class ChatService {
                 getByClientEmailAndCaretakerEmail(participantUsername, username);
 
         return mapToChatRoomDTO(username, chatRoom, timeZone);
-    }
-
-    public Page<ChatRoomDTO> getChatRoomsByParticipantEmailSortedByLastMessage(String principalEmail,
-                                                                               Role role,
-                                                                               Pageable pageable,
-                                                                               ZoneId timeZone) {
-        Page<ChatRoom> principalChatRooms = role == Role.CLIENT ?
-                chatRoomRepository.findByClientEmailOrderByLastMessageDesc(principalEmail, pageable) :
-                chatRoomRepository.findByCaretakerEmailOrderByLastMessageDesc(principalEmail, pageable);
-
-        return principalChatRooms.map(room -> mapToChatRoomDTO(principalEmail, room, timeZone));
     }
 
     public String getMessageReceiverEmail(String senderEmail, ChatRoom chatRoom) {

--- a/src/main/java/com/example/petbuddybackend/service/chat/ChatService.java
+++ b/src/main/java/com/example/petbuddybackend/service/chat/ChatService.java
@@ -97,9 +97,11 @@ public class ChatService {
     }
 
     public UnseenChatsNotificationDTO getUnseenChatsNumberNotification(String userEmail) {
-        return UnseenChatsNotificationDTO.builder().createdAt(ZonedDateTime.now())
+        return UnseenChatsNotificationDTO.builder()
+                .createdAt(ZonedDateTime.now())
                 .unseenChatsAsClient(chatRepository.countUnreadChatsForUserAsClient(userEmail))
-                .unseenChatsAsCaretaker(chatRepository.countUnreadChatsForUserAsCaretaker(userEmail)).build();
+                .unseenChatsAsCaretaker(chatRepository.countUnreadChatsForUserAsCaretaker(userEmail))
+                .build();
     }
 
     @Transactional

--- a/src/main/java/com/example/petbuddybackend/service/mapper/ChatMapper.java
+++ b/src/main/java/com/example/petbuddybackend/service/mapper/ChatMapper.java
@@ -13,7 +13,7 @@ import org.mapstruct.factory.Mappers;
 import java.time.ZoneId;
 import java.time.ZonedDateTime;
 
-@Mapper
+@Mapper(uses = UserMapper.class)
 public interface ChatMapper {
 
     ChatMapper INSTANCE = Mappers.getMapper(ChatMapper.class);
@@ -27,30 +27,23 @@ public interface ChatMapper {
     @Mapping(target = "chatId", source = "chatRoom.id")
     ChatMessageDTO mapToChatMessageDTO(ChatMessage chatMessage);
 
-    @Mapping(target = "createdAt", source = "createdAt", qualifiedByName = "mapToZonedDateTime")
-    ChatMessageDTO mapTimeZone(ChatMessageDTO chatMessage, @Context ZoneId zoneId);
-
-    @Mapping(target = "lastMessageCreatedAt", source = "lastMessageCreatedAt", qualifiedByName = "mapToZonedDateTime")
-    ChatRoomDTO mapTimeZone(ChatRoomDTO chatRoom, @Context ZoneId zoneId);
-
     @Mapping(target = "id", source = "id")
-    @Mapping(target = "chatterEmail", source = "chatter.email")
-    @Mapping(target = "chatterName", source = "chatter.name")
-    @Mapping(target = "chatterSurname", source = "chatter.surname")
-    @Mapping(target = "lastMessageSendBy", source = "lastMessage.sender.email")
-    @Mapping(target = "lastMessage", source = "lastMessage.content")
-    @Mapping(target = "lastMessageCreatedAt", source = "lastMessage.createdAt", qualifiedByName = "mapToZonedDateTime")
+    @Mapping(target = "lastMessage", expression = "java(mapToChatMessageDTO(lastMessage, zoneId))")
     ChatRoomDTO mapToChatRoomDTO(
             Long id,
             AppUser chatter,
             ChatMessage lastMessage,
-            boolean seenByPrincipal,
             @Context ZoneId zoneId
     );
+
+    @Mapping(target = "createdAt", source = "createdAt", qualifiedByName = "mapToZonedDateTime")
+    ChatMessageDTO mapTimeZone(ChatMessageDTO chatMessage, @Context ZoneId zoneId);
+
+    @Mapping(target = "lastMessage.createdAt", source = "lastMessage.createdAt", qualifiedByName = "mapToZonedDateTime")
+    ChatRoomDTO mapTimeZone(ChatRoomDTO chatRoom, @Context ZoneId zoneId);
 
     @Named("mapToZonedDateTime")
     default ZonedDateTime mapToZonedDateTime(ZonedDateTime date, @Context ZoneId zoneId) {
         return date.withZoneSameInstant(zoneId);
     }
-
 }

--- a/src/test/java/com/example/petbuddybackend/controller/ChatControllerTest.java
+++ b/src/test/java/com/example/petbuddybackend/controller/ChatControllerTest.java
@@ -2,6 +2,7 @@ package com.example.petbuddybackend.controller;
 
 import com.example.petbuddybackend.dto.chat.ChatMessageDTO;
 import com.example.petbuddybackend.dto.chat.ChatRoomDTO;
+import com.example.petbuddybackend.dto.user.AccountDataDTO;
 import com.example.petbuddybackend.entity.user.Role;
 import com.example.petbuddybackend.service.chat.ChatService;
 import org.junit.jupiter.api.BeforeEach;
@@ -71,11 +72,16 @@ public class ChatControllerTest {
 
         expectedChatRoom = ChatRoomDTO.builder()
                 .id(1L)
-                .chatterEmail("chatter1")
-                .chatterName("name1")
-                .chatterSurname("surname1")
-                .lastMessage("lastMessage1")
-                .lastMessageCreatedAt(ZonedDateTime.now())
+                .chatter(AccountDataDTO.builder()
+                        .email("chatter1")
+                        .name("chatter1")
+                        .surname("chatterSurname1")
+                        .build())
+                .lastMessage(ChatMessageDTO.builder()
+                        .createdAt(ZonedDateTime.now())
+                        .content("lastMessage1")
+                        .chatId(1L)
+                        .build())
                 .build();
 
         expectedChatRoomPage = new PageImpl<>(
@@ -87,7 +93,7 @@ public class ChatControllerTest {
     @Test
     @WithMockUser
     void getChatRooms_includeTimeZone_shouldSucceed() throws Exception {
-        when(chatService.getChatRoomsByParticipantEmail(any(), any(), any(), any()))
+        when(chatService.getChatRoomsByParticipantEmailSortedByLastMessage(any(), any(), any(), any()))
                 .thenReturn(expectedChatRoomPage);
 
         mockMvc.perform(get("/api/chat")

--- a/src/test/java/com/example/petbuddybackend/repository/chat/ChatRoomRepositoryTest.java
+++ b/src/test/java/com/example/petbuddybackend/repository/chat/ChatRoomRepositoryTest.java
@@ -1,6 +1,5 @@
 package com.example.petbuddybackend.repository.chat;
 
-import com.example.petbuddybackend.dto.chat.ChatRoomDTO;
 import com.example.petbuddybackend.entity.chat.ChatMessage;
 import com.example.petbuddybackend.entity.chat.ChatRoom;
 import com.example.petbuddybackend.entity.user.Caretaker;
@@ -9,28 +8,20 @@ import com.example.petbuddybackend.repository.user.AppUserRepository;
 import com.example.petbuddybackend.repository.user.CaretakerRepository;
 import com.example.petbuddybackend.repository.user.ClientRepository;
 import com.example.petbuddybackend.testutils.PersistenceUtils;
-import com.example.petbuddybackend.testutils.ValidationUtils;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.data.domain.Page;
-import org.springframework.data.domain.PageRequest;
-import org.springframework.data.domain.Pageable;
-import org.springframework.transaction.annotation.Transactional;
 import org.springframework.transaction.support.TransactionTemplate;
 
 import java.time.ZonedDateTime;
-import java.util.Comparator;
 import java.util.List;
-import java.util.stream.Collectors;
 
 import static com.example.petbuddybackend.testutils.mock.MockChatProvider.*;
 import static com.example.petbuddybackend.testutils.mock.MockUserProvider.createMockCaretaker;
 import static com.example.petbuddybackend.testutils.mock.MockUserProvider.createMockClient;
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertTrue;
 
 @SpringBootTest
 public class ChatRoomRepositoryTest {
@@ -57,7 +48,6 @@ public class ChatRoomRepositoryTest {
     private TransactionTemplate transactionTemplate;
 
     private ChatRoom chatRoomSameCreatedAtFst;
-    private ChatRoom chatRoomSameCreatedAtSnd;
     private ChatRoom chatRoomDifferentCreatedAt;
 
     @BeforeEach
@@ -82,16 +72,6 @@ public class ChatRoomRepositoryTest {
                 "caretakerSameCreatedAtFst",
                 sameDateTime
         );
-        chatRoomSameCreatedAtSnd = PersistenceUtils.createChatRoomWithMessages(
-                appUserRepository,
-                clientRepository,
-                caretakerRepository,
-                chatRoomRepository,
-                chatMessageRepository,
-                "clientSameCreatedAtSnd",
-                "caretakerSameCreatedAtSnd",
-                sameDateTime
-        );
     }
 
     @AfterEach
@@ -101,100 +81,6 @@ public class ChatRoomRepositoryTest {
         caretakerRepository.deleteAll();
         appUserRepository.deleteAll();
     }
-
-    @Test
-    void testFindByCaretakerEmail_messagesWithDifferentCreatedAT_shouldReturnChatRoomDTOs() {
-        Pageable pageable = PageRequest.of(0, 10);
-        Page<ChatRoomDTO> chatRooms =
-                chatRepository.findByCaretakerEmailSortByLastMessageDesc(chatRoomDifferentCreatedAt.getCaretaker().getEmail(), pageable);
-
-        // Chat rooms have different created at messages so the latest message should be the latest created at message
-        ChatRoomDTO returnedChatRoom = chatRooms.getContent().get(0);
-        ChatMessage messageThatShouldBeLatest = chatRoomDifferentCreatedAt.getMessages().stream()
-                .max(Comparator.comparing(ChatMessage::getCreatedAt))
-                .get();
-
-        assertTrue(allMessagesHaveDifferentCreatedAt(chatRoomDifferentCreatedAt.getMessages()));
-        assertEquals(1, chatRooms.getTotalElements());
-        assertTrue(ValidationUtils.fieldsNotNullRecursive(chatRooms.getContent().get(0)));
-        assertEquals(messageThatShouldBeLatest.getContent(), returnedChatRoom.getLastMessage());
-    }
-
-    @Test
-    @Transactional
-    void testFindByClientEmail_messagesWithDifferentCreatedAT_shouldReturnChatRoomDTOs() {
-        Pageable pageable = PageRequest.of(0, 10);
-        Page<ChatRoomDTO> chatRooms =
-                chatRepository.findByClientEmailSortByLastMessageDesc(chatRoomDifferentCreatedAt.getClient().getEmail(), pageable);
-
-        // Chat rooms have different created at messages so the latest message should be the latest created at message
-        ChatRoomDTO returnedChatRoom = chatRooms.getContent().get(0);
-        ChatMessage messageThatShouldBeLatest = chatRoomDifferentCreatedAt.getMessages().stream()
-                .max(Comparator.comparing(ChatMessage::getCreatedAt))
-                .get();
-
-        assertTrue(allMessagesHaveDifferentCreatedAt(chatRoomDifferentCreatedAt.getMessages()));
-        assertEquals(1, chatRooms.getTotalElements());
-        assertTrue(ValidationUtils.fieldsNotNullRecursive(chatRooms.getContent().get(0)));
-        assertEquals(messageThatShouldBeLatest.getContent(), returnedChatRoom.getLastMessage());
-    }
-
-    @Test
-    void testFindByCaretakerEmail_messagesWithSameCreatedAT_shouldReturnChatRoomDTOs() {
-        Pageable pageable = PageRequest.of(0, 10);
-        Page<ChatRoomDTO> chatRooms =
-                chatRepository.findByCaretakerEmailSortByLastMessageDesc(chatRoomSameCreatedAtFst.getCaretaker().getEmail(), pageable);
-
-        // Chat rooms have same created at messages so the latest message should be the message with the lowest id
-        ChatRoomDTO returnedChatRoom = chatRooms.getContent().get(0);
-        ChatMessage messageThatShouldBeLatest = chatRoomSameCreatedAtFst.getMessages().stream()
-                .min(Comparator.comparing(ChatMessage::getId))
-                .get();
-
-        assertTrue(allMessagesHaveSameCreatedAt(chatRoomSameCreatedAtFst.getMessages()));
-        assertEquals(1, chatRooms.getTotalElements());
-        assertTrue(ValidationUtils.fieldsNotNullRecursive(chatRooms.getContent().get(0)));
-        assertEquals(messageThatShouldBeLatest.getContent(), returnedChatRoom.getLastMessage());
-    }
-
-    @Test
-    void testFindByClientEmail_messagesWithSameCreatedAT_shouldReturnChatRoomDTOs() {
-        Pageable pageable = PageRequest.of(0, 10);
-        Page<ChatRoomDTO> chatRooms =
-                chatRepository.findByClientEmailSortByLastMessageDesc(chatRoomSameCreatedAtFst.getClient().getEmail(), pageable);
-
-        // Chat rooms have same created at messages so the latest message should be the message with the lowest id
-        ChatRoomDTO returnedChatRoom = chatRooms.getContent().get(0);
-        ChatMessage messageThatShouldBeLatest = chatRoomSameCreatedAtFst.getMessages().stream()
-                .min(Comparator.comparing(ChatMessage::getId))
-                .get();
-
-        assertTrue(allMessagesHaveSameCreatedAt(chatRoomSameCreatedAtFst.getMessages()));
-        assertEquals(1, chatRooms.getTotalElements());
-        assertTrue(ValidationUtils.fieldsNotNullRecursive(chatRooms.getContent().get(0)));
-        assertEquals(messageThatShouldBeLatest.getContent(), returnedChatRoom.getLastMessage());
-    }
-
-    @Test
-    void testFindByCaretakerEmail_differentChatRoomsWithSameMessageCreatedAt_shouldReturnCorrectChatRoomWithMessage() {
-        Pageable pageable = PageRequest.of(0, 10);
-        Page<ChatRoomDTO> chatRooms =
-                chatRepository.findByCaretakerEmailSortByLastMessageDesc(chatRoomSameCreatedAtSnd.getCaretaker().getEmail(), pageable);
-
-        assertEquals(1, chatRooms.getTotalElements());
-        assertEquals(chatRoomSameCreatedAtSnd.getClient().getEmail(), chatRooms.getContent().get(0).getLastMessageSendBy());
-    }
-
-    @Test
-    void testFindByClientEmail_differentChatRoomsWithSameMessageCreatedAt_shouldReturnCorrectChatRoomWithMessage() {
-        Pageable pageable = PageRequest.of(0, 10);
-        Page<ChatRoomDTO> chatRooms =
-                chatRepository.findByClientEmailSortByLastMessageDesc(chatRoomSameCreatedAtSnd.getClient().getEmail(), pageable);
-
-        assertEquals(1, chatRooms.getTotalElements());
-        assertEquals(chatRoomSameCreatedAtSnd.getClient().getEmail(), chatRooms.getContent().get(0).getLastMessageSendBy());
-    }
-
 
     @Test
     void testCountUnreadChatsForUser_whenMessagesAtDifferentTime_shouldReturnCorrectCount() {
@@ -293,19 +179,5 @@ public class ChatRoomRepositoryTest {
         //Then
         assertEquals(0, countUnreadChats);
 
-    }
-
-    private boolean allMessagesHaveSameCreatedAt(List<ChatMessage> messages) {
-        return messages.stream()
-                .map(ChatMessage::getCreatedAt)
-                .collect(Collectors.toSet())
-                .size() == 1;
-    }
-
-    private boolean allMessagesHaveDifferentCreatedAt(List<ChatMessage> messages) {
-        return messages.stream()
-                .map(ChatMessage::getCreatedAt)
-                .collect(Collectors.toSet())
-                .size() == messages.size();
     }
 }

--- a/src/test/java/com/example/petbuddybackend/repository/chat/ChatRoomRepositoryTest.java
+++ b/src/test/java/com/example/petbuddybackend/repository/chat/ChatRoomRepositoryTest.java
@@ -57,7 +57,6 @@ public class ChatRoomRepositoryTest {
     private TransactionTemplate transactionTemplate;
 
     private ChatRoom chatRoomSameCreatedAtFst;
-    private ChatRoom chatRoomSameCreatedAtSnd;
     private ChatRoom chatRoomDifferentCreatedAt;
 
     @BeforeEach
@@ -82,16 +81,6 @@ public class ChatRoomRepositoryTest {
                 "caretakerSameCreatedAtFst",
                 sameDateTime
         );
-        chatRoomSameCreatedAtSnd = PersistenceUtils.createChatRoomWithMessages(
-                appUserRepository,
-                clientRepository,
-                caretakerRepository,
-                chatRoomRepository,
-                chatMessageRepository,
-                "clientSameCreatedAtSnd",
-                "caretakerSameCreatedAtSnd",
-                sameDateTime
-        );
     }
 
     @AfterEach
@@ -101,100 +90,6 @@ public class ChatRoomRepositoryTest {
         caretakerRepository.deleteAll();
         appUserRepository.deleteAll();
     }
-
-    @Test
-    void testFindByCaretakerEmail_messagesWithDifferentCreatedAT_shouldReturnChatRoomDTOs() {
-        Pageable pageable = PageRequest.of(0, 10);
-        Page<ChatRoomDTO> chatRooms =
-                chatRepository.findByCaretakerEmailSortByLastMessageDesc(chatRoomDifferentCreatedAt.getCaretaker().getEmail(), pageable);
-
-        // Chat rooms have different created at messages so the latest message should be the latest created at message
-        ChatRoomDTO returnedChatRoom = chatRooms.getContent().get(0);
-        ChatMessage messageThatShouldBeLatest = chatRoomDifferentCreatedAt.getMessages().stream()
-                .max(Comparator.comparing(ChatMessage::getCreatedAt))
-                .get();
-
-        assertTrue(allMessagesHaveDifferentCreatedAt(chatRoomDifferentCreatedAt.getMessages()));
-        assertEquals(1, chatRooms.getTotalElements());
-        assertTrue(ValidationUtils.fieldsNotNullRecursive(chatRooms.getContent().get(0)));
-        assertEquals(messageThatShouldBeLatest.getContent(), returnedChatRoom.getLastMessage());
-    }
-
-    @Test
-    @Transactional
-    void testFindByClientEmail_messagesWithDifferentCreatedAT_shouldReturnChatRoomDTOs() {
-        Pageable pageable = PageRequest.of(0, 10);
-        Page<ChatRoomDTO> chatRooms =
-                chatRepository.findByClientEmailSortByLastMessageDesc(chatRoomDifferentCreatedAt.getClient().getEmail(), pageable);
-
-        // Chat rooms have different created at messages so the latest message should be the latest created at message
-        ChatRoomDTO returnedChatRoom = chatRooms.getContent().get(0);
-        ChatMessage messageThatShouldBeLatest = chatRoomDifferentCreatedAt.getMessages().stream()
-                .max(Comparator.comparing(ChatMessage::getCreatedAt))
-                .get();
-
-        assertTrue(allMessagesHaveDifferentCreatedAt(chatRoomDifferentCreatedAt.getMessages()));
-        assertEquals(1, chatRooms.getTotalElements());
-        assertTrue(ValidationUtils.fieldsNotNullRecursive(chatRooms.getContent().get(0)));
-        assertEquals(messageThatShouldBeLatest.getContent(), returnedChatRoom.getLastMessage());
-    }
-
-    @Test
-    void testFindByCaretakerEmail_messagesWithSameCreatedAT_shouldReturnChatRoomDTOs() {
-        Pageable pageable = PageRequest.of(0, 10);
-        Page<ChatRoomDTO> chatRooms =
-                chatRepository.findByCaretakerEmailSortByLastMessageDesc(chatRoomSameCreatedAtFst.getCaretaker().getEmail(), pageable);
-
-        // Chat rooms have same created at messages so the latest message should be the message with the lowest id
-        ChatRoomDTO returnedChatRoom = chatRooms.getContent().get(0);
-        ChatMessage messageThatShouldBeLatest = chatRoomSameCreatedAtFst.getMessages().stream()
-                .min(Comparator.comparing(ChatMessage::getId))
-                .get();
-
-        assertTrue(allMessagesHaveSameCreatedAt(chatRoomSameCreatedAtFst.getMessages()));
-        assertEquals(1, chatRooms.getTotalElements());
-        assertTrue(ValidationUtils.fieldsNotNullRecursive(chatRooms.getContent().get(0)));
-        assertEquals(messageThatShouldBeLatest.getContent(), returnedChatRoom.getLastMessage());
-    }
-
-    @Test
-    void testFindByClientEmail_messagesWithSameCreatedAT_shouldReturnChatRoomDTOs() {
-        Pageable pageable = PageRequest.of(0, 10);
-        Page<ChatRoomDTO> chatRooms =
-                chatRepository.findByClientEmailSortByLastMessageDesc(chatRoomSameCreatedAtFst.getClient().getEmail(), pageable);
-
-        // Chat rooms have same created at messages so the latest message should be the message with the lowest id
-        ChatRoomDTO returnedChatRoom = chatRooms.getContent().get(0);
-        ChatMessage messageThatShouldBeLatest = chatRoomSameCreatedAtFst.getMessages().stream()
-                .min(Comparator.comparing(ChatMessage::getId))
-                .get();
-
-        assertTrue(allMessagesHaveSameCreatedAt(chatRoomSameCreatedAtFst.getMessages()));
-        assertEquals(1, chatRooms.getTotalElements());
-        assertTrue(ValidationUtils.fieldsNotNullRecursive(chatRooms.getContent().get(0)));
-        assertEquals(messageThatShouldBeLatest.getContent(), returnedChatRoom.getLastMessage());
-    }
-
-    @Test
-    void testFindByCaretakerEmail_differentChatRoomsWithSameMessageCreatedAt_shouldReturnCorrectChatRoomWithMessage() {
-        Pageable pageable = PageRequest.of(0, 10);
-        Page<ChatRoomDTO> chatRooms =
-                chatRepository.findByCaretakerEmailSortByLastMessageDesc(chatRoomSameCreatedAtSnd.getCaretaker().getEmail(), pageable);
-
-        assertEquals(1, chatRooms.getTotalElements());
-        assertEquals(chatRoomSameCreatedAtSnd.getClient().getEmail(), chatRooms.getContent().get(0).getLastMessageSendBy());
-    }
-
-    @Test
-    void testFindByClientEmail_differentChatRoomsWithSameMessageCreatedAt_shouldReturnCorrectChatRoomWithMessage() {
-        Pageable pageable = PageRequest.of(0, 10);
-        Page<ChatRoomDTO> chatRooms =
-                chatRepository.findByClientEmailSortByLastMessageDesc(chatRoomSameCreatedAtSnd.getClient().getEmail(), pageable);
-
-        assertEquals(1, chatRooms.getTotalElements());
-        assertEquals(chatRoomSameCreatedAtSnd.getClient().getEmail(), chatRooms.getContent().get(0).getLastMessageSendBy());
-    }
-
 
     @Test
     void testCountUnreadChatsForUser_whenMessagesAtDifferentTime_shouldReturnCorrectCount() {
@@ -293,19 +188,5 @@ public class ChatRoomRepositoryTest {
         //Then
         assertEquals(0, countUnreadChats);
 
-    }
-
-    private boolean allMessagesHaveSameCreatedAt(List<ChatMessage> messages) {
-        return messages.stream()
-                .map(ChatMessage::getCreatedAt)
-                .collect(Collectors.toSet())
-                .size() == 1;
-    }
-
-    private boolean allMessagesHaveDifferentCreatedAt(List<ChatMessage> messages) {
-        return messages.stream()
-                .map(ChatMessage::getCreatedAt)
-                .collect(Collectors.toSet())
-                .size() == messages.size();
     }
 }

--- a/src/test/java/com/example/petbuddybackend/service/chat/ChatServiceTest.java
+++ b/src/test/java/com/example/petbuddybackend/service/chat/ChatServiceTest.java
@@ -190,13 +190,13 @@ public class ChatServiceTest {
     void testGetChatRoomsByParticipantEmail_shouldSucceed() {
         Pageable pageable = PageRequest.of(0, 10);
 
-        Page<ChatRoomDTO> clientChatRooms = chatService.getChatRoomsByParticipantEmail(
+        Page<ChatRoomDTO> clientChatRooms = chatService.getChatRoomsByParticipantEmailSortedByLastMessage(
                 client.getEmail(),
                 Role.CLIENT,
                 pageable,
                 ZoneId.of("Europe/Warsaw")
         );
-        Page<ChatRoomDTO> caretakerChatRooms = chatService.getChatRoomsByParticipantEmail(
+        Page<ChatRoomDTO> caretakerChatRooms = chatService.getChatRoomsByParticipantEmailSortedByLastMessage(
                 caretaker.getEmail(),
                 Role.CARETAKER,
                 pageable,
@@ -207,17 +207,17 @@ public class ChatServiceTest {
         ChatRoomDTO caretakerChatRoom = caretakerChatRooms.getContent().get(0);
 
         assertEquals(1, clientChatRooms.getContent().size());
-        assertEquals(caretaker.getEmail(), clientChatRoom.getChatterEmail());
-        assertEquals(client.getEmail(), caretakerChatRoom.getChatterEmail());
+        assertEquals(caretaker.getEmail(), clientChatRoom.getChatter().email());
+        assertEquals(client.getEmail(), caretakerChatRoom.getChatter().email());
 
-        assertEquals(caretaker.getAccountData().getName(), clientChatRoom.getChatterName());
-        assertEquals(client.getAccountData().getName(), caretakerChatRoom.getChatterName());
+        assertEquals(caretaker.getAccountData().getName(), clientChatRoom.getChatter().name());
+        assertEquals(client.getAccountData().getName(), caretakerChatRoom.getChatter().name());
 
-        assertEquals(caretaker.getAccountData().getSurname(), clientChatRoom.getChatterSurname());
-        assertEquals(client.getAccountData().getSurname(), caretakerChatRoom.getChatterSurname());
+        assertEquals(caretaker.getAccountData().getSurname(), clientChatRoom.getChatter().surname());
+        assertEquals(client.getAccountData().getSurname(), caretakerChatRoom.getChatter().surname());
 
-        assertNotNull(clientChatRoom.getLastMessageCreatedAt());
-        assertNotNull(caretakerChatRoom.getLastMessageCreatedAt());
+        assertNotNull(clientChatRoom.getLastMessage().getCreatedAt());
+        assertNotNull(caretakerChatRoom.getLastMessage().getCreatedAt());
     }
 
     @ParameterizedTest
@@ -225,7 +225,7 @@ public class ChatServiceTest {
     void testGetChatRoomsByParticipantEmailWithZone_shouldSucceed(String timeZone) {
         Pageable pageable = PageRequest.of(0, 10);
 
-        Page<ChatRoomDTO> chatRooms = chatService.getChatRoomsByParticipantEmail(
+        Page<ChatRoomDTO> chatRooms = chatService.getChatRoomsByParticipantEmailSortedByLastMessage(
                 client.getEmail(),
                 Role.CLIENT,
                 pageable,
@@ -233,7 +233,7 @@ public class ChatServiceTest {
         );
 
         for(ChatRoomDTO chatRoomDTO : chatRooms.getContent()) {
-            assertEquals(ZoneId.of(timeZone), chatRoomDTO.getLastMessageCreatedAt().getZone());
+            assertEquals(ZoneId.of(timeZone), chatRoomDTO.getLastMessage().getCreatedAt().getZone());
         }
     }
 
@@ -545,8 +545,8 @@ public class ChatServiceTest {
     ) {
         ChatRoomDTO chatRoomDTO = chatService.getChatRoomWithParticipant(username, role, participantUsername, ZoneId.systemDefault());
         assertEquals(chatRoom.getId(), chatRoomDTO.getId());
-        assertEquals(participantUsername, chatRoomDTO.getChatterEmail());
-        assertNotNull(chatRoomDTO.getLastMessageCreatedAt());
+        assertEquals(participantUsername, chatRoomDTO.getChatter().email());
+        assertNotNull(chatRoomDTO.getLastMessage().getCreatedAt());
     }
 
     @ParameterizedTest

--- a/src/test/java/com/example/petbuddybackend/service/mapper/ChatMapperTest.java
+++ b/src/test/java/com/example/petbuddybackend/service/mapper/ChatMapperTest.java
@@ -67,11 +67,14 @@ public class ChatMapperTest {
     @Test
     void mapTimeZoneFromChatRoomDTO_shouldChangeTimeZone() {
         ChatRoomDTO chatRoomDTO = ChatRoomDTO.builder()
-                .lastMessageCreatedAt(ZonedDateTime.now().withZoneSameInstant(tokyoZone))
+                .lastMessage(
+                        ChatMessageDTO.builder()
+                                .createdAt(ZonedDateTime.now().withZoneSameInstant(tokyoZone))
+                                .build())
                 .build();
 
         ChatRoomDTO mappedChatMessageWithNewZone = mapper.mapTimeZone(chatRoomDTO, warsawZone);
-        ZoneId newZone = mappedChatMessageWithNewZone.getLastMessageCreatedAt().getZone();
+        ZoneId newZone = mappedChatMessageWithNewZone.getLastMessage().getCreatedAt().getZone();
 
         assertEquals(warsawZone, newZone);
     }
@@ -80,9 +83,8 @@ public class ChatMapperTest {
     void mapToChatRoomDTO_shouldNotLeaveNullFields() {
         ChatRoomDTO mappedChatRoom = mapper.mapToChatRoomDTO(
                 1L,
-                MockUserProvider.createMockAppUser(),
+                MockUserProvider.createMockAppUserWithPhoto(),
                 chatMessage,
-                true,
                 ZoneId.systemDefault()
         );
         assertTrue(ValidationUtils.fieldsNotNullRecursive(mappedChatRoom));

--- a/src/test/java/com/example/petbuddybackend/testutils/mock/MockUserProvider.java
+++ b/src/test/java/com/example/petbuddybackend/testutils/mock/MockUserProvider.java
@@ -138,6 +138,12 @@ public final class MockUserProvider {
                 .build();
     }
 
+    public static AppUser createMockAppUserWithPhoto() {
+        AppUser user = createMockAppUser();
+        user.setProfilePicture(createMockPhotoLink());
+        return user;
+    }
+
     public static AppUser createMockAppUser() {
         return createMockAppUser("name", "surname", "email");
     }


### PR DESCRIPTION
- dodałem zdjęcie profilowe do ChatRoomDTO
- uprościłem Query do ChatRoomDTO. Poprzednie użycie Query było mało skalowalne. Teraz ostatnia wiadomość jest osobno pobierana. Tutaj ze strony klienta i tak nie umożliwiamy sortowania więc nie będzie problemu że nie zgadzają się nazwy pól
- użyłem formatera ale działa on mniej więcej w 50% przypadków więc i tak ręcznie poprawiałem