### PR TITLE
gawron/ZPI-47-ZPI-72-BE-99-Dodanie-informacji-o-wywolujacym-powiadomienie

### DIFF
--- a/src/main/java/com/example/petbuddybackend/controller/NotificationController.java
+++ b/src/main/java/com/example/petbuddybackend/controller/NotificationController.java
@@ -55,7 +55,6 @@ public class NotificationController {
     @PreAuthorize("isAuthenticated()")
     public Page<SimplyNotificationDTO> getNotifications(
             @ParameterObject @ModelAttribute @Valid SortedPagingParams pagingParams,
-            @RequestParam(required = false, defaultValue = "false") Boolean read,
             Principal principal,
             @RoleParameter
             @RequestHeader(value = "${header-name.role}") Role role,
@@ -67,7 +66,6 @@ public class NotificationController {
                 pageable,
                 principal.getName(),
                 role,
-                read,
                 TimeUtils.getOrSystemDefault(timezone)
         );
     }

--- a/src/main/java/com/example/petbuddybackend/controller/NotificationController.java
+++ b/src/main/java/com/example/petbuddybackend/controller/NotificationController.java
@@ -32,7 +32,9 @@ public class NotificationController {
             description =
                     """
                             ## Endpoint description
-                            Get unread notifications for the current logged user for current profile.
+                            Get unread notifications for the current logged user for current profile if read set to false.
+                            Get read notifications for the current logged user for current profile if read set to true.
+                            By default read is set to false.
                             
                             ## Docs for websocket notifications:
                             
@@ -49,10 +51,11 @@ public class NotificationController {
                             - CHAT_NOTIFICATION
                             """
     )
-    @GetMapping
+    @GetMapping()
     @PreAuthorize("isAuthenticated()")
-    public Page<SimplyNotificationDTO> getUnreadNotifications(
+    public Page<SimplyNotificationDTO> getNotifications(
             @ParameterObject @ModelAttribute @Valid SortedPagingParams pagingParams,
+            @RequestParam(required = false, defaultValue = "false") Boolean read,
             Principal principal,
             @RoleParameter
             @RequestHeader(value = "${header-name.role}") Role role,
@@ -60,10 +63,11 @@ public class NotificationController {
             @TimeZoneParameter
             @RequestHeader(value = "${header-name.timezone}", required = false) String timezone) {
         Pageable pageable = PagingUtils.createSortedPageable(pagingParams);
-        return notificationService.getUnreadNotifications(
+        return notificationService.getNotifications(
                 pageable,
                 principal.getName(),
                 role,
+                read,
                 TimeUtils.getOrSystemDefault(timezone)
         );
     }

--- a/src/main/java/com/example/petbuddybackend/dto/notification/SimplyNotificationDTO.java
+++ b/src/main/java/com/example/petbuddybackend/dto/notification/SimplyNotificationDTO.java
@@ -1,5 +1,6 @@
 package com.example.petbuddybackend.dto.notification;
 
+import com.example.petbuddybackend.dto.user.AccountDataDTO;
 import com.example.petbuddybackend.entity.notification.ObjectType;
 import com.example.petbuddybackend.entity.user.Role;
 import lombok.*;
@@ -19,5 +20,6 @@ public class SimplyNotificationDTO extends NotificationDTO {
     private String messageKey;
     private Set<String> args;
     private Role receiverProfile;
+    private AccountDataDTO triggeredBy;
     private boolean isRead;
 }

--- a/src/main/java/com/example/petbuddybackend/dto/notification/SimplyNotificationDTO.java
+++ b/src/main/java/com/example/petbuddybackend/dto/notification/SimplyNotificationDTO.java
@@ -3,7 +3,10 @@ package com.example.petbuddybackend.dto.notification;
 import com.example.petbuddybackend.dto.user.AccountDataDTO;
 import com.example.petbuddybackend.entity.notification.ObjectType;
 import com.example.petbuddybackend.entity.user.Role;
-import lombok.*;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
 import lombok.experimental.SuperBuilder;
 
 import java.util.Set;
@@ -21,5 +24,5 @@ public class SimplyNotificationDTO extends NotificationDTO {
     private Set<String> args;
     private Role receiverProfile;
     private AccountDataDTO triggeredBy;
-    private boolean isRead;
+    private boolean read;
 }

--- a/src/main/java/com/example/petbuddybackend/entity/notification/CaretakerNotification.java
+++ b/src/main/java/com/example/petbuddybackend/entity/notification/CaretakerNotification.java
@@ -25,7 +25,7 @@ public class CaretakerNotification extends Notification {
     private Caretaker caretaker;
 
     @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "triggeredBy", nullable = false, updatable = false)
-    private Client triggeredBy;
+    @JoinColumn(name = "clientTriggerEmail", nullable = false, updatable = false)
+    private Client clientTrigger;
 
 }

--- a/src/main/java/com/example/petbuddybackend/entity/notification/CaretakerNotification.java
+++ b/src/main/java/com/example/petbuddybackend/entity/notification/CaretakerNotification.java
@@ -1,6 +1,7 @@
 package com.example.petbuddybackend.entity.notification;
 
 import com.example.petbuddybackend.entity.user.Caretaker;
+import com.example.petbuddybackend.entity.user.Client;
 import jakarta.persistence.Entity;
 import jakarta.persistence.FetchType;
 import jakarta.persistence.JoinColumn;
@@ -22,5 +23,9 @@ public class CaretakerNotification extends Notification {
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "caretakerEmail", nullable = false, updatable = false)
     private Caretaker caretaker;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "triggeredBy", nullable = false, updatable = false)
+    private Client triggeredBy;
 
 }

--- a/src/main/java/com/example/petbuddybackend/entity/notification/ClientNotification.java
+++ b/src/main/java/com/example/petbuddybackend/entity/notification/ClientNotification.java
@@ -1,5 +1,6 @@
 package com.example.petbuddybackend.entity.notification;
 
+import com.example.petbuddybackend.entity.user.Caretaker;
 import com.example.petbuddybackend.entity.user.Client;
 import jakarta.persistence.Entity;
 import jakarta.persistence.FetchType;
@@ -22,5 +23,9 @@ public class ClientNotification extends Notification {
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "clientEmail", nullable = false, updatable = false)
     private Client client;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "triggeredBy", nullable = false, updatable = false)
+    private Caretaker triggeredBy;
 
 }

--- a/src/main/java/com/example/petbuddybackend/entity/notification/ClientNotification.java
+++ b/src/main/java/com/example/petbuddybackend/entity/notification/ClientNotification.java
@@ -25,7 +25,7 @@ public class ClientNotification extends Notification {
     private Client client;
 
     @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "triggeredBy", nullable = false, updatable = false)
-    private Caretaker triggeredBy;
+    @JoinColumn(name = "caretakerTriggeredEmail", nullable = false, updatable = false)
+    private Caretaker caretakerTriggered;
 
 }

--- a/src/main/java/com/example/petbuddybackend/entity/notification/Notification.java
+++ b/src/main/java/com/example/petbuddybackend/entity/notification/Notification.java
@@ -39,14 +39,14 @@ public class Notification {
     private Set<String> args;
 
     @Column(nullable = false)
-    private boolean isRead;
+    private boolean read;
 
     @PrePersist
     public void prePersist() {
         if (createdAt == null) {
             createdAt = ZonedDateTime.now();
         }
-        isRead = false;
+        read = false;
     }
 
 }

--- a/src/main/java/com/example/petbuddybackend/repository/notification/CaretakerNotificationRepository.java
+++ b/src/main/java/com/example/petbuddybackend/repository/notification/CaretakerNotificationRepository.java
@@ -16,9 +16,9 @@ public interface CaretakerNotificationRepository extends JpaRepository<Caretaker
     @Transactional
     @Query("""
         UPDATE CaretakerNotification n
-        SET n.isRead = true
+        SET n.read = true
         WHERE n.caretaker.email = :caretakerEmail
-            AND n.isRead = false
+            AND n.read = false
 
     """)
     void markAllNotificationsOfCaretakerAsRead(String caretakerEmail);

--- a/src/main/java/com/example/petbuddybackend/repository/notification/CaretakerNotificationRepository.java
+++ b/src/main/java/com/example/petbuddybackend/repository/notification/CaretakerNotificationRepository.java
@@ -10,8 +10,7 @@ import org.springframework.transaction.annotation.Transactional;
 
 public interface CaretakerNotificationRepository extends JpaRepository<CaretakerNotification, Long> {
 
-    Page<CaretakerNotification> getCaretakerNotificationByCaretaker_EmailAndIsRead(String caretaker_email, boolean isRead,
-                                                                                 Pageable pageable);
+    Page<CaretakerNotification> getCaretakerNotificationByCaretaker_Email(String caretaker_email, Pageable pageable);
 
     @Modifying
     @Transactional

--- a/src/main/java/com/example/petbuddybackend/repository/notification/ClientNotificationRepository.java
+++ b/src/main/java/com/example/petbuddybackend/repository/notification/ClientNotificationRepository.java
@@ -16,9 +16,9 @@ public interface ClientNotificationRepository extends JpaRepository<ClientNotifi
     @Transactional
     @Query("""
         UPDATE ClientNotification n
-        SET n.isRead = true
+        SET n.read = true
         WHERE n.client.email = :clientEmail
-            AND n.isRead = false
+            AND n.read = false
 
     """)
     void markAllNotificationsOfClientAsRead(String clientEmail);

--- a/src/main/java/com/example/petbuddybackend/repository/notification/ClientNotificationRepository.java
+++ b/src/main/java/com/example/petbuddybackend/repository/notification/ClientNotificationRepository.java
@@ -10,8 +10,7 @@ import org.springframework.transaction.annotation.Transactional;
 
 public interface ClientNotificationRepository extends JpaRepository<ClientNotification, Long> {
 
-    Page<ClientNotification> getClientNotificationByClient_EmailAndIsRead(String client_email, boolean isRead,
-                                                                        Pageable pageable);
+    Page<ClientNotification> getClientNotificationByClient_Email(String client_email, Pageable pageable);
 
     @Modifying
     @Transactional

--- a/src/main/java/com/example/petbuddybackend/service/care/CareService.java
+++ b/src/main/java/com/example/petbuddybackend/service/care/CareService.java
@@ -219,6 +219,7 @@ public class CareService {
                 care.getId(),
                 ObjectType.CARE,
                 client,
+                caretaker,
                 message,
                 Set.of(
                         MessageFormat.format(NAME_SURNAME_FORMAT,
@@ -235,10 +236,12 @@ public class CareService {
                 care.getId(),
                 ObjectType.CARE,
                 caretaker,
+                client,
                 message,
                 Set.of(
                         MessageFormat.format(NAME_SURNAME_FORMAT,
-                                client.getAccountData().getName(), client.getAccountData().getSurname())
+                                client.getAccountData().getName(), client.getAccountData().getSurname()
+                        )
                 )
         );
     }

--- a/src/main/java/com/example/petbuddybackend/service/mapper/NotificationMapper.java
+++ b/src/main/java/com/example/petbuddybackend/service/mapper/NotificationMapper.java
@@ -24,11 +24,13 @@ public interface NotificationMapper {
     @Mapping(target = "createdAt", source = "createdAt", qualifiedByName = "mapToZonedDateTime")
     @Mapping(target = "receiverProfile", source = "notification", qualifiedByName = "mapToReceiverProfile")
     @Mapping(target = "triggeredBy", source = "notification", qualifiedByName = "mapTriggeredByToUserDTO")
+    @Mapping(target = "read", source = "notification.read")
     SimplyNotificationDTO mapToSimplyNotificationDTO(Notification notification, @Context ZoneId zoneId);
 
     @Mapping(target = "notificationId", source = "id")
     @Mapping(target = "receiverProfile", source = "notification", qualifiedByName = "mapToReceiverProfile")
     @Mapping(target = "triggeredBy", source = "notification", qualifiedByName = "mapTriggeredByToUserDTO")
+    @Mapping(target = "read", source = "notification.read")
     SimplyNotificationDTO mapToSimplyNotificationDTO(Notification notification);
 
     @Named("mapToZonedDateTime")

--- a/src/main/java/com/example/petbuddybackend/service/mapper/NotificationMapper.java
+++ b/src/main/java/com/example/petbuddybackend/service/mapper/NotificationMapper.java
@@ -43,7 +43,7 @@ public interface NotificationMapper {
         } else if(notification instanceof CaretakerNotification) {
             return Role.CARETAKER;
         } else {
-            throw new IllegalStateException("Unknown receiver profile type");
+            throw new UnsupportedOperationException("Unknown receiver profile type");
         }
     }
 
@@ -51,14 +51,14 @@ public interface NotificationMapper {
     default AccountDataDTO mapTriggeredByToUserDTO(Notification notification) {
         if(notification instanceof ClientNotification) {
             return UserMapper.INSTANCE.mapToAccountDataDTO(
-                    ((ClientNotification) notification).getTriggeredBy().getAccountData()
+                    ((ClientNotification) notification).getCaretakerTriggered().getAccountData()
             );
         } else if(notification instanceof CaretakerNotification) {
             return UserMapper.INSTANCE.mapToAccountDataDTO(
-                    ((CaretakerNotification) notification).getTriggeredBy().getAccountData()
+                    ((CaretakerNotification) notification).getClientTrigger().getAccountData()
             );
         } else {
-            throw new IllegalStateException("Unknown receiver profile type");
+            throw new UnsupportedOperationException("Unknown receiver profile type");
         }
     }
 

--- a/src/main/java/com/example/petbuddybackend/service/notification/NotificationService.java
+++ b/src/main/java/com/example/petbuddybackend/service/notification/NotificationService.java
@@ -98,6 +98,7 @@ public class NotificationService {
                 false,
                 pageable
                 )
+                .map(this::renewProfilePictureOfTriggeredByUser)
                 .map(caretakerNotification ->
                         notificationMapper.mapToSimplyNotificationDTO(caretakerNotification, timezone));
     }
@@ -109,6 +110,7 @@ public class NotificationService {
                 false,
                 pageable
                 )
+                .map(this::renewProfilePictureOfTriggeredByUser)
                 .map(clientNotification -> notificationMapper.mapToSimplyNotificationDTO(clientNotification, timezone));
     }
 
@@ -135,4 +137,16 @@ public class NotificationService {
                 .triggeredBy(triggeredBy)
                 .build();
     }
+
+    private Notification renewProfilePictureOfTriggeredByUser(Notification notification) {
+        if(notification instanceof CaretakerNotification) {
+            CaretakerNotification caretakerNotification = (CaretakerNotification) notification;
+            userService.renewProfilePicture(caretakerNotification.getTriggeredBy().getAccountData());
+        } else {
+            ClientNotification clientNotification = (ClientNotification) notification;
+            userService.renewProfilePicture(clientNotification.getTriggeredBy().getAccountData());
+        }
+        return notification;
+    }
+
 }

--- a/src/main/java/com/example/petbuddybackend/service/notification/NotificationService.java
+++ b/src/main/java/com/example/petbuddybackend/service/notification/NotificationService.java
@@ -36,8 +36,8 @@ public class NotificationService {
     private final NotificationMapper notificationMapper = NotificationMapper.INSTANCE;
 
     public void addNotificationForCaretakerAndSend(Long objectId, ObjectType objectType, Caretaker caretaker,
-                                                   String messageKey, Set<String> args) {
-        CaretakerNotification notification = createCaretakerNotification(objectId, objectType, caretaker,
+                                                   Client triggeredBy, String messageKey, Set<String> args) {
+        CaretakerNotification notification = createCaretakerNotification(objectId, objectType, caretaker, triggeredBy,
                 messageKey, args);
         CaretakerNotification savedNotification = caretakerNotificationRepository.save(notification);
         websocketNotificationSender.sendNotification(
@@ -47,8 +47,9 @@ public class NotificationService {
     }
 
     public void addNotificationForClientAndSend(Long objectId, ObjectType objectType, Client client,
-                                                String messageKey, Set<String> args) {
-        ClientNotification notification = createClientNotification(objectId, objectType, client, messageKey, args);
+                                                Caretaker triggeredBy, String messageKey, Set<String> args) {
+        ClientNotification notification = createClientNotification(objectId, objectType, client, triggeredBy,
+                messageKey, args);
         ClientNotification savedNotification = clientNotificationRepository.save(notification);
         websocketNotificationSender.sendNotification(
                 client.getEmail(),
@@ -108,24 +109,26 @@ public class NotificationService {
     }
 
     private CaretakerNotification createCaretakerNotification(Long objectId, ObjectType objectType, Caretaker caretaker,
-                                                              String messageKey, Set<String> args) {
+                                                              Client triggeredBy, String messageKey, Set<String> args) {
         return CaretakerNotification.builder()
                 .objectId(objectId)
                 .objectType(objectType)
                 .messageKey(messageKey)
                 .args(args)
                 .caretaker(caretaker)
+                .triggeredBy(triggeredBy)
                 .build();
     }
 
     private ClientNotification createClientNotification(Long objectId, ObjectType objectType, Client client,
-                                                        String messageKey, Set<String> args) {
+                                                        Caretaker triggeredBy, String messageKey, Set<String> args) {
         return ClientNotification.builder()
                 .objectId(objectId)
                 .objectType(objectType)
                 .messageKey(messageKey)
                 .args(args)
                 .client(client)
+                .triggeredBy(triggeredBy)
                 .build();
     }
 }

--- a/src/main/java/com/example/petbuddybackend/service/notification/NotificationService.java
+++ b/src/main/java/com/example/petbuddybackend/service/notification/NotificationService.java
@@ -84,11 +84,10 @@ public class NotificationService {
     public Page<SimplyNotificationDTO> getNotifications(Pageable pageable,
                                                         String userEmail,
                                                         Role userRole,
-                                                        Boolean read,
                                                         ZoneId timezone) {
         return userRole == Role.CARETAKER
-                ? getCaretakerNotifications(pageable, userEmail, read, timezone)
-                : getClientNotifications(pageable, userEmail, read, timezone);
+                ? getCaretakerNotifications(pageable, userEmail, timezone)
+                : getClientNotifications(pageable, userEmail, timezone);
     }
 
     public SimplyNotificationDTO markNotificationAsRead(Long notificationId, Role role, ZoneId timezone) {
@@ -122,11 +121,9 @@ public class NotificationService {
 
     private Page<SimplyNotificationDTO> getCaretakerNotifications(Pageable pageable,
                                                                   String caretakerEmail,
-                                                                  Boolean read,
                                                                   ZoneId timezone) {
-        return caretakerNotificationRepository.getCaretakerNotificationByCaretaker_EmailAndIsRead(
+        return caretakerNotificationRepository.getCaretakerNotificationByCaretaker_Email(
                                                       caretakerEmail,
-                                                      read,
                                                       pageable
                                               )
                                               .map(this::renewProfilePictureOfTriggeredByUser)
@@ -138,9 +135,8 @@ public class NotificationService {
 
     private Page<SimplyNotificationDTO> getClientNotifications(Pageable pageable,
                                                                String clientEmail,
-                                                               Boolean read,
                                                                ZoneId timezone) {
-        return clientNotificationRepository.getClientNotificationByClient_EmailAndIsRead(clientEmail, read, pageable)
+        return clientNotificationRepository.getClientNotificationByClient_Email(clientEmail, pageable)
                                            .map(this::renewProfilePictureOfTriggeredByUser)
                                            .map(clientNotification -> notificationMapper.mapToSimplyNotificationDTO(
                                                    clientNotification,

--- a/src/main/java/com/example/petbuddybackend/service/notification/NotificationService.java
+++ b/src/main/java/com/example/petbuddybackend/service/notification/NotificationService.java
@@ -37,10 +37,20 @@ public class NotificationService {
 
     private final NotificationMapper notificationMapper = NotificationMapper.INSTANCE;
 
-    public void addNotificationForCaretakerAndSend(Long objectId, ObjectType objectType, Caretaker caretaker,
-                                                   Client triggeredBy, String messageKey, Set<String> args) {
-        CaretakerNotification notification = createCaretakerNotification(objectId, objectType, caretaker, triggeredBy,
-                messageKey, args);
+    public void addNotificationForCaretakerAndSend(Long objectId,
+                                                   ObjectType objectType,
+                                                   Caretaker caretaker,
+                                                   Client triggeredBy,
+                                                   String messageKey,
+                                                   Set<String> args) {
+        CaretakerNotification notification = createCaretakerNotification(
+                objectId,
+                objectType,
+                caretaker,
+                triggeredBy,
+                messageKey,
+                args
+        );
         userService.renewProfilePicture(triggeredBy.getAccountData());
         CaretakerNotification savedNotification = caretakerNotificationRepository.save(notification);
         websocketNotificationSender.sendNotification(
@@ -49,10 +59,20 @@ public class NotificationService {
         );
     }
 
-    public void addNotificationForClientAndSend(Long objectId, ObjectType objectType, Client client,
-                                                Caretaker triggeredBy, String messageKey, Set<String> args) {
-        ClientNotification notification = createClientNotification(objectId, objectType, client, triggeredBy,
-                messageKey, args);
+    public void addNotificationForClientAndSend(Long objectId,
+                                                ObjectType objectType,
+                                                Client client,
+                                                Caretaker triggeredBy,
+                                                String messageKey,
+                                                Set<String> args) {
+        ClientNotification notification = createClientNotification(
+                objectId,
+                objectType,
+                client,
+                triggeredBy,
+                messageKey,
+                args
+        );
         userService.renewProfilePicture(triggeredBy.getAccountData());
         ClientNotification savedNotification = clientNotificationRepository.save(notification);
         websocketNotificationSender.sendNotification(
@@ -91,7 +111,8 @@ public class NotificationService {
                 .orElseThrow(() -> NotFoundException.withFormattedMessage(CLIENT_NOTIFICATION, id.toString()));
     }
 
-    private Page<SimplyNotificationDTO> getCaretakerUnreadNotifications(Pageable pageable, String caretakerEmail,
+    private Page<SimplyNotificationDTO> getCaretakerUnreadNotifications(Pageable pageable,
+                                                                        String caretakerEmail,
                                                                         ZoneId timezone) {
         return caretakerNotificationRepository.getCaretakerNotificationByCaretaker_EmailAndIsRead(
                 caretakerEmail,
@@ -103,7 +124,8 @@ public class NotificationService {
                         notificationMapper.mapToSimplyNotificationDTO(caretakerNotification, timezone));
     }
 
-    private Page<SimplyNotificationDTO> getClientUnreadNotifications(Pageable pageable, String clientEmail,
+    private Page<SimplyNotificationDTO> getClientUnreadNotifications(Pageable pageable,
+                                                                     String clientEmail,
                                                                      ZoneId timezone) {
         return clientNotificationRepository.getClientNotificationByClient_EmailAndIsRead(
                 clientEmail,
@@ -114,37 +136,45 @@ public class NotificationService {
                 .map(clientNotification -> notificationMapper.mapToSimplyNotificationDTO(clientNotification, timezone));
     }
 
-    private CaretakerNotification createCaretakerNotification(Long objectId, ObjectType objectType, Caretaker caretaker,
-                                                              Client triggeredBy, String messageKey, Set<String> args) {
+    private CaretakerNotification createCaretakerNotification(Long objectId,
+                                                              ObjectType objectType,
+                                                              Caretaker caretaker,
+                                                              Client triggeredBy,
+                                                              String messageKey,
+                                                              Set<String> args) {
         return CaretakerNotification.builder()
                 .objectId(objectId)
                 .objectType(objectType)
                 .messageKey(messageKey)
                 .args(args)
                 .caretaker(caretaker)
-                .triggeredBy(triggeredBy)
+                .clientTrigger(triggeredBy)
                 .build();
     }
 
-    private ClientNotification createClientNotification(Long objectId, ObjectType objectType, Client client,
-                                                        Caretaker triggeredBy, String messageKey, Set<String> args) {
+    private ClientNotification createClientNotification(Long objectId,
+                                                        ObjectType objectType,
+                                                        Client client,
+                                                        Caretaker triggeredBy,
+                                                        String messageKey,
+                                                        Set<String> args) {
         return ClientNotification.builder()
                 .objectId(objectId)
                 .objectType(objectType)
                 .messageKey(messageKey)
                 .args(args)
                 .client(client)
-                .triggeredBy(triggeredBy)
+                .caretakerTriggered(triggeredBy)
                 .build();
     }
 
     private Notification renewProfilePictureOfTriggeredByUser(Notification notification) {
         if(notification instanceof CaretakerNotification) {
             CaretakerNotification caretakerNotification = (CaretakerNotification) notification;
-            userService.renewProfilePicture(caretakerNotification.getTriggeredBy().getAccountData());
+            userService.renewProfilePicture(caretakerNotification.getClientTrigger().getAccountData());
         } else {
             ClientNotification clientNotification = (ClientNotification) notification;
-            userService.renewProfilePicture(clientNotification.getTriggeredBy().getAccountData());
+            userService.renewProfilePicture(clientNotification.getCaretakerTriggered().getAccountData());
         }
         return notification;
     }

--- a/src/main/java/com/example/petbuddybackend/service/notification/NotificationService.java
+++ b/src/main/java/com/example/petbuddybackend/service/notification/NotificationService.java
@@ -87,8 +87,8 @@ public class NotificationService {
                                                         Boolean read,
                                                         ZoneId timezone) {
         return userRole == Role.CARETAKER
-                ? getCaretakerUnreadNotifications(pageable, userEmail, read, timezone)
-                : getClientUnreadNotifications(pageable, userEmail, read, timezone);
+                ? getCaretakerNotifications(pageable, userEmail, read, timezone)
+                : getClientNotifications(pageable, userEmail, read, timezone);
     }
 
     public SimplyNotificationDTO markNotificationAsRead(Long notificationId, Role role, ZoneId timezone) {
@@ -120,10 +120,10 @@ public class NotificationService {
                                               ));
     }
 
-    private Page<SimplyNotificationDTO> getCaretakerUnreadNotifications(Pageable pageable,
-                                                                        String caretakerEmail,
-                                                                        Boolean read,
-                                                                        ZoneId timezone) {
+    private Page<SimplyNotificationDTO> getCaretakerNotifications(Pageable pageable,
+                                                                  String caretakerEmail,
+                                                                  Boolean read,
+                                                                  ZoneId timezone) {
         return caretakerNotificationRepository.getCaretakerNotificationByCaretaker_EmailAndIsRead(
                                                       caretakerEmail,
                                                       read,
@@ -136,10 +136,10 @@ public class NotificationService {
                                               ));
     }
 
-    private Page<SimplyNotificationDTO> getClientUnreadNotifications(Pageable pageable,
-                                                                     String clientEmail,
-                                                                     Boolean read,
-                                                                     ZoneId timezone) {
+    private Page<SimplyNotificationDTO> getClientNotifications(Pageable pageable,
+                                                               String clientEmail,
+                                                               Boolean read,
+                                                               ZoneId timezone) {
         return clientNotificationRepository.getClientNotificationByClient_EmailAndIsRead(clientEmail, read, pageable)
                                            .map(this::renewProfilePictureOfTriggeredByUser)
                                            .map(clientNotification -> notificationMapper.mapToSimplyNotificationDTO(

--- a/src/main/java/com/example/petbuddybackend/service/notification/NotificationService.java
+++ b/src/main/java/com/example/petbuddybackend/service/notification/NotificationService.java
@@ -12,6 +12,7 @@ import com.example.petbuddybackend.repository.notification.CaretakerNotification
 import com.example.petbuddybackend.repository.notification.ClientNotificationRepository;
 import com.example.petbuddybackend.repository.notification.NotificationRepository;
 import com.example.petbuddybackend.service.mapper.NotificationMapper;
+import com.example.petbuddybackend.service.user.UserService;
 import com.example.petbuddybackend.utils.exception.throweable.general.NotFoundException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
@@ -32,6 +33,7 @@ public class NotificationService {
     private final ClientNotificationRepository clientNotificationRepository;
     private final NotificationRepository notificationRepository;
     private final WebsocketNotificationSender websocketNotificationSender;
+    private final UserService userService;
 
     private final NotificationMapper notificationMapper = NotificationMapper.INSTANCE;
 
@@ -39,6 +41,7 @@ public class NotificationService {
                                                    Client triggeredBy, String messageKey, Set<String> args) {
         CaretakerNotification notification = createCaretakerNotification(objectId, objectType, caretaker, triggeredBy,
                 messageKey, args);
+        userService.renewProfilePicture(triggeredBy.getAccountData());
         CaretakerNotification savedNotification = caretakerNotificationRepository.save(notification);
         websocketNotificationSender.sendNotification(
                 caretaker.getEmail(),
@@ -50,6 +53,7 @@ public class NotificationService {
                                                 Caretaker triggeredBy, String messageKey, Set<String> args) {
         ClientNotification notification = createClientNotification(objectId, objectType, client, triggeredBy,
                 messageKey, args);
+        userService.renewProfilePicture(triggeredBy.getAccountData());
         ClientNotification savedNotification = clientNotificationRepository.save(notification);
         websocketNotificationSender.sendNotification(
                 client.getEmail(),

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -10,7 +10,7 @@ spring:
     password: ${DB_PASSWORD}
   jpa:
     hibernate:
-      ddl-auto: update
+      ddl-auto: create
     properties:
       dialect: org.hibernate.dialect.PostgreSQL94Dialect
       hibernate:

--- a/src/test/java/com/example/petbuddybackend/controller/CareControllerIntegrationTest.java
+++ b/src/test/java/com/example/petbuddybackend/controller/CareControllerIntegrationTest.java
@@ -7,6 +7,8 @@ import com.example.petbuddybackend.entity.user.Client;
 import com.example.petbuddybackend.entity.user.Role;
 import com.example.petbuddybackend.repository.animal.AnimalRepository;
 import com.example.petbuddybackend.repository.care.CareRepository;
+import com.example.petbuddybackend.repository.notification.CaretakerNotificationRepository;
+import com.example.petbuddybackend.repository.notification.ClientNotificationRepository;
 import com.example.petbuddybackend.repository.user.AppUserRepository;
 import com.example.petbuddybackend.repository.user.CaretakerRepository;
 import com.example.petbuddybackend.repository.user.ClientRepository;
@@ -62,6 +64,12 @@ public class CareControllerIntegrationTest {
     @Autowired
     private ClientRepository clientRepository;
 
+    @Autowired
+    private ClientNotificationRepository clientNotificationRepository;
+
+    @Autowired
+    private CaretakerNotificationRepository caretakerNotificationRepository;
+
     private static final String CREATE_CARE_BODY = """
             {
                 "careStart": "%s",
@@ -92,6 +100,8 @@ public class CareControllerIntegrationTest {
 
     @AfterEach
     void tearDown() {
+        clientNotificationRepository.deleteAll();
+        caretakerNotificationRepository.deleteAll();
         careRepository.deleteAll();
         appUserRepository.deleteAll();
     }

--- a/src/test/java/com/example/petbuddybackend/controller/NotificationControllerTest.java
+++ b/src/test/java/com/example/petbuddybackend/controller/NotificationControllerTest.java
@@ -42,11 +42,11 @@ public class NotificationControllerTest {
 
     @Test
     @WithMockUser("caretakerEmail")
-    void getUnreadNotifications_shouldReturnProperAnswer() throws Exception {
+    void getNotifications_shouldReturnProperAnswer() throws Exception {
         Pageable pageable = PageRequest.of(0, 10);
         Page<SimplyNotificationDTO> emptyPage = new PageImpl<>(Collections.emptyList(), pageable, 0);
 
-        when(notificationService.getUnreadNotifications(any(), any(), any(), any()))
+        when(notificationService.getNotifications(any(), any(), any(), any(), any()))
                 .thenReturn(emptyPage);
 
         mockMvc.perform(get("/api/notifications")

--- a/src/test/java/com/example/petbuddybackend/controller/NotificationControllerTest.java
+++ b/src/test/java/com/example/petbuddybackend/controller/NotificationControllerTest.java
@@ -46,7 +46,7 @@ public class NotificationControllerTest {
         Pageable pageable = PageRequest.of(0, 10);
         Page<SimplyNotificationDTO> emptyPage = new PageImpl<>(Collections.emptyList(), pageable, 0);
 
-        when(notificationService.getNotifications(any(), any(), any(), any(), any()))
+        when(notificationService.getNotifications(any(), any(), any(), any()))
                 .thenReturn(emptyPage);
 
         mockMvc.perform(get("/api/notifications")

--- a/src/test/java/com/example/petbuddybackend/service/care/CareServiceIntegrationTest.java
+++ b/src/test/java/com/example/petbuddybackend/service/care/CareServiceIntegrationTest.java
@@ -971,7 +971,7 @@ public class CareServiceIntegrationTest {
 
         //Then
         verify(notificationService, times(2))
-                .addNotificationForCaretakerAndSend(anyLong(), any(), any(), anyString(), any());
+                .addNotificationForCaretakerAndSend(anyLong(), any(), any(), any(), anyString(), any());
 
     }
 

--- a/src/test/java/com/example/petbuddybackend/service/care/CareServiceIntegrationTest.java
+++ b/src/test/java/com/example/petbuddybackend/service/care/CareServiceIntegrationTest.java
@@ -13,6 +13,8 @@ import com.example.petbuddybackend.entity.user.Client;
 import com.example.petbuddybackend.entity.user.Role;
 import com.example.petbuddybackend.repository.animal.AnimalRepository;
 import com.example.petbuddybackend.repository.care.CareRepository;
+import com.example.petbuddybackend.repository.notification.CaretakerNotificationRepository;
+import com.example.petbuddybackend.repository.notification.ClientNotificationRepository;
 import com.example.petbuddybackend.repository.user.AppUserRepository;
 import com.example.petbuddybackend.repository.user.CaretakerRepository;
 import com.example.petbuddybackend.repository.user.ClientRepository;
@@ -20,11 +22,11 @@ import com.example.petbuddybackend.service.notification.NotificationService;
 import com.example.petbuddybackend.testconfig.TestDataConfiguration;
 import com.example.petbuddybackend.testutils.PersistenceUtils;
 import com.example.petbuddybackend.testutils.ReflectionUtils;
-import com.example.petbuddybackend.utils.exception.throweable.user.InvalidRoleException;
-import com.example.petbuddybackend.utils.exception.throweable.general.StateTransitionException;
 import com.example.petbuddybackend.utils.exception.throweable.general.ForbiddenException;
 import com.example.petbuddybackend.utils.exception.throweable.general.IllegalActionException;
 import com.example.petbuddybackend.utils.exception.throweable.general.NotFoundException;
+import com.example.petbuddybackend.utils.exception.throweable.general.StateTransitionException;
+import com.example.petbuddybackend.utils.exception.throweable.user.InvalidRoleException;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -52,10 +54,10 @@ import java.util.stream.Stream;
 
 import static com.example.petbuddybackend.testutils.mock.MockUserProvider.createMockCaretaker;
 import static com.example.petbuddybackend.testutils.mock.MockUserProvider.createMockClient;
-import static org.mockito.Mockito.times;
-import static org.mockito.Mockito.verify;
 import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
 
 @SpringBootTest
 @ContextConfiguration(classes = TestDataConfiguration.class)
@@ -80,6 +82,12 @@ public class CareServiceIntegrationTest {
     private CareService careService;
 
     @Autowired
+    private CaretakerNotificationRepository caretakerNotificationRepository;
+
+    @Autowired
+    private ClientNotificationRepository clientNotificationRepository;
+
+    @Autowired
     private TransactionTemplate transactionTemplate;
 
     @SpyBean
@@ -96,6 +104,8 @@ public class CareServiceIntegrationTest {
 
     @AfterEach
     public void tearDown() {
+        caretakerNotificationRepository.deleteAll();
+        clientNotificationRepository.deleteAll();
         careRepository.deleteAll();
         appUserRepository.deleteAll();
     }

--- a/src/test/java/com/example/petbuddybackend/service/mapper/NotificationMapperTest.java
+++ b/src/test/java/com/example/petbuddybackend/service/mapper/NotificationMapperTest.java
@@ -10,8 +10,7 @@ import java.time.ZoneId;
 
 import static com.example.petbuddybackend.testutils.mock.MockNotificationProvider.createMockCaretakerNotification;
 import static com.example.petbuddybackend.testutils.mock.MockNotificationProvider.createMockClientNotification;
-import static com.example.petbuddybackend.testutils.mock.MockUserProvider.createMockCaretaker;
-import static com.example.petbuddybackend.testutils.mock.MockUserProvider.createMockClient;
+import static com.example.petbuddybackend.testutils.mock.MockUserProvider.*;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class NotificationMapperTest {
@@ -22,7 +21,7 @@ public class NotificationMapperTest {
     void mapToNotificationDTO_whenNotificationForCaretaker_shouldNotLeaveNullFields() {
 
         //Given
-        CaretakerNotification notification = createMockCaretakerNotification(createMockCaretaker());
+        CaretakerNotification notification = createMockCaretakerNotification(createMockCaretaker(), createMockClientWithPhoto("client"));
         notification.setId(1L);
 
         SimplyNotificationDTO simplyNotificationDTO = mapper.mapToSimplyNotificationDTO(notification, ZoneId.systemDefault());
@@ -34,7 +33,7 @@ public class NotificationMapperTest {
     void mapToNotificationDTO_whenNotificationForClient_shouldNotLeaveNullFields() {
 
         //Given
-        ClientNotification notification = createMockClientNotification(createMockClient());
+        ClientNotification notification = createMockClientNotification(createMockClient(), createMockCaretakerWithPhoto("caretaker"));
         notification.setId(1L);
 
         SimplyNotificationDTO simplyNotificationDTO = mapper.mapToSimplyNotificationDTO(notification, ZoneId.systemDefault());

--- a/src/test/java/com/example/petbuddybackend/service/notification/NotificationServiceTest.java
+++ b/src/test/java/com/example/petbuddybackend/service/notification/NotificationServiceTest.java
@@ -137,7 +137,6 @@ public class NotificationServiceTest {
                     PageRequest.of(0, 10, Sort.by(Sort.Direction.ASC, fieldName)),
                     "test",
                     Role.CARETAKER,
-                    false,
                     ZoneId.systemDefault()
             ));
         }
@@ -168,7 +167,6 @@ public class NotificationServiceTest {
                     PageRequest.of(0, 10),
                     caretaker.getEmail(),
                     Role.CARETAKER,
-                    false,
                     ZoneId.systemDefault()
             );
             assertEquals(2, result.getTotalElements());

--- a/src/test/java/com/example/petbuddybackend/service/notification/NotificationServiceTest.java
+++ b/src/test/java/com/example/petbuddybackend/service/notification/NotificationServiceTest.java
@@ -149,13 +149,13 @@ public class NotificationServiceTest {
         //Given
         transactionTemplate.execute(status -> {
             CaretakerNotification notification1 = PersistenceUtils.addCaretakerNotification(
-                    caretakerNotificationRepository, caretaker
+                    caretakerNotificationRepository, caretaker, client
             );
             CaretakerNotification notification2 = PersistenceUtils.addCaretakerNotification(
-                    caretakerNotificationRepository, caretaker
+                    caretakerNotificationRepository, caretaker, client
             );
             CaretakerNotification readNotification = PersistenceUtils.addCaretakerNotification(
-                    caretakerNotificationRepository, caretaker
+                    caretakerNotificationRepository, caretaker, client
             );
             readNotification.setRead(true);
             return null;
@@ -181,7 +181,7 @@ public class NotificationServiceTest {
         //Given
         Long notificationId = transactionTemplate.execute(status -> {
             CaretakerNotification notification = PersistenceUtils.addCaretakerNotification(
-                    caretakerNotificationRepository, caretaker
+                    caretakerNotificationRepository, caretaker, client
             );
             return notification.getId();
         });
@@ -223,7 +223,7 @@ public class NotificationServiceTest {
         //Given
         Long notificationId = transactionTemplate.execute(status -> {
             CaretakerNotification notification = PersistenceUtils.addCaretakerNotification(
-                    caretakerNotificationRepository, caretaker
+                    caretakerNotificationRepository, caretaker, client
             );
             return notification.getId();
         });

--- a/src/test/java/com/example/petbuddybackend/service/notification/NotificationServiceTest.java
+++ b/src/test/java/com/example/petbuddybackend/service/notification/NotificationServiceTest.java
@@ -125,7 +125,7 @@ public class NotificationServiceTest {
     }
 
     @Test
-    void testGetUnreadNotifications_sortingParamsShouldAlignWithDTO() {
+    void testGetNotifications_sortingParamsShouldAlignWithDTO() {
 
         List<String> fieldNames = ReflectionUtils.getPrimitiveNames(SimplyNotificationDTO.class);
         fieldNames.remove("notificationId");
@@ -133,10 +133,11 @@ public class NotificationServiceTest {
         fieldNames.remove("dType");
 
         for(String fieldName : fieldNames) {
-            assertDoesNotThrow(() -> notificationService.getUnreadNotifications(
+            assertDoesNotThrow(() -> notificationService.getNotifications(
                     PageRequest.of(0, 10, Sort.by(Sort.Direction.ASC, fieldName)),
                     "test",
                     Role.CARETAKER,
+                    false,
                     ZoneId.systemDefault()
             ));
         }
@@ -144,7 +145,7 @@ public class NotificationServiceTest {
     }
 
     @Test
-    void getUnreadNotifications_shouldGetOnlyUnreadNotifications() {
+    void getNotifications_shouldGetOnlyNotifications() {
 
         //Given
         transactionTemplate.execute(status -> {
@@ -163,10 +164,11 @@ public class NotificationServiceTest {
 
         //When Then
         transactionTemplate.execute(status -> {
-            Page<SimplyNotificationDTO> result = notificationService.getUnreadNotifications(
+            Page<SimplyNotificationDTO> result = notificationService.getNotifications(
                     PageRequest.of(0, 10),
                     caretaker.getEmail(),
                     Role.CARETAKER,
+                    false,
                     ZoneId.systemDefault()
             );
             assertEquals(2, result.getTotalElements());

--- a/src/test/java/com/example/petbuddybackend/service/notification/NotificationServiceTest.java
+++ b/src/test/java/com/example/petbuddybackend/service/notification/NotificationServiceTest.java
@@ -144,18 +144,18 @@ public class NotificationServiceTest {
     }
 
     @Test
-    void getNotifications_shouldGetOnlyNotifications() {
+    void getNotifications_shouldGetAllNotifications() {
 
         //Given
         transactionTemplate.execute(status -> {
             CaretakerNotification notification1 = PersistenceUtils.addCaretakerNotification(
-                    caretakerNotificationRepository, caretaker, client
+                    caretakerNotificationRepository, caretaker, client, 1L
             );
             CaretakerNotification notification2 = PersistenceUtils.addCaretakerNotification(
-                    caretakerNotificationRepository, caretaker, client
+                    caretakerNotificationRepository, caretaker, client, 2L
             );
             CaretakerNotification readNotification = PersistenceUtils.addCaretakerNotification(
-                    caretakerNotificationRepository, caretaker, client
+                    caretakerNotificationRepository, caretaker, client, 3L
             );
             readNotification.setRead(true);
             return null;
@@ -169,7 +169,7 @@ public class NotificationServiceTest {
                     Role.CARETAKER,
                     ZoneId.systemDefault()
             );
-            assertEquals(2, result.getTotalElements());
+            assertEquals(3, result.getTotalElements());
             return null;
         });
 

--- a/src/test/java/com/example/petbuddybackend/service/notification/NotificationServiceTest.java
+++ b/src/test/java/com/example/petbuddybackend/service/notification/NotificationServiceTest.java
@@ -85,7 +85,7 @@ public class NotificationServiceTest {
     void testAddNotificationForCaretakerAndSend_shouldAddNotificationAndSend() {
 
         //Given When
-        notificationService.addNotificationForCaretakerAndSend(1L, ObjectType.CARE, caretaker,
+        notificationService.addNotificationForCaretakerAndSend(1L, ObjectType.CARE, caretaker, client,
                 "messageKey", Set.of("clientEmail"));
 
         //Then
@@ -107,7 +107,7 @@ public class NotificationServiceTest {
     void testAddNotificationForClientAndSend_shouldAddNotificationAndSend() {
 
         //Given When
-        notificationService.addNotificationForClientAndSend(1L, ObjectType.CARE, client,
+        notificationService.addNotificationForClientAndSend(1L, ObjectType.CARE, client, caretaker,
                 "messageKey", Set.of("caretakerEmail"));
 
         //Then

--- a/src/test/java/com/example/petbuddybackend/service/notification/WebsocketNotificationSenderTest.java
+++ b/src/test/java/com/example/petbuddybackend/service/notification/WebsocketNotificationSenderTest.java
@@ -22,6 +22,7 @@ import java.util.Collections;
 
 import static com.example.petbuddybackend.testutils.mock.MockNotificationProvider.createMockCaretakerNotification;
 import static com.example.petbuddybackend.testutils.mock.MockUserProvider.createMockCaretaker;
+import static com.example.petbuddybackend.testutils.mock.MockUserProvider.createMockClient;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.Mockito.*;
 
@@ -63,7 +64,7 @@ public class WebsocketNotificationSenderTest {
         wsSessionService.storeUserTimeZoneWithSession(sessionId, userZoneId);
 
         //When
-        CaretakerNotification notification = createMockCaretakerNotification(createMockCaretaker());
+        CaretakerNotification notification = createMockCaretakerNotification(createMockCaretaker(), createMockClient());
         SimplyNotificationDTO notificationToSend = notificationMapper.mapToSimplyNotificationDTO(notification, ZoneId.of(userZoneId));
 
         wsNotificationSender.sendNotification(userEmail, notificationToSend);
@@ -99,7 +100,7 @@ public class WebsocketNotificationSenderTest {
     public void testSendNotification_whenUserNotConnected_shouldNotSendMessage() {
         //Given
         when(simpUserRegistry.getUser(userEmail)).thenReturn(null);
-        CaretakerNotification notification = createMockCaretakerNotification(createMockCaretaker());
+        CaretakerNotification notification = createMockCaretakerNotification(createMockCaretaker(), createMockClient());
         SimplyNotificationDTO notificationToSend = notificationMapper.mapToSimplyNotificationDTO(notification, ZoneId.of(userZoneId));
 
         //When

--- a/src/test/java/com/example/petbuddybackend/testutils/PersistenceUtils.java
+++ b/src/test/java/com/example/petbuddybackend/testutils/PersistenceUtils.java
@@ -262,4 +262,10 @@ public class PersistenceUtils {
         return caretakerNotificationRepository.saveAndFlush(notification);
     }
 
+    public static CaretakerNotification addCaretakerNotification(CaretakerNotificationRepository caretakerNotificationRepository,
+                                                                 Caretaker caretaker, Client client, Long id) {
+        CaretakerNotification notification = createMockCaretakerNotification(caretaker, client, id);
+        return caretakerNotificationRepository.saveAndFlush(notification);
+    }
+
 }

--- a/src/test/java/com/example/petbuddybackend/testutils/PersistenceUtils.java
+++ b/src/test/java/com/example/petbuddybackend/testutils/PersistenceUtils.java
@@ -257,8 +257,8 @@ public class PersistenceUtils {
     }
 
     public static CaretakerNotification addCaretakerNotification(CaretakerNotificationRepository caretakerNotificationRepository,
-                                                                 Caretaker caretaker) {
-        CaretakerNotification notification = createMockCaretakerNotification(caretaker);
+                                                                 Caretaker caretaker, Client client) {
+        CaretakerNotification notification = createMockCaretakerNotification(caretaker, client);
         return caretakerNotificationRepository.saveAndFlush(notification);
     }
 

--- a/src/test/java/com/example/petbuddybackend/testutils/mock/MockNotificationProvider.java
+++ b/src/test/java/com/example/petbuddybackend/testutils/mock/MockNotificationProvider.java
@@ -13,7 +13,7 @@ import java.util.Set;
 @NoArgsConstructor(access = lombok.AccessLevel.PRIVATE)
 public final class MockNotificationProvider {
 
-    public static CaretakerNotification createMockCaretakerNotification(Caretaker caretaker) {
+    public static CaretakerNotification createMockCaretakerNotification(Caretaker caretaker, Client client) {
         return CaretakerNotification.builder()
                 .id(1L)
                 .objectId(1L)
@@ -23,10 +23,11 @@ public final class MockNotificationProvider {
                 .createdAt(ZonedDateTime.now())
                 .isRead(false)
                 .caretaker(caretaker)
+                .triggeredBy(client)
                 .build();
     }
 
-    public static ClientNotification createMockClientNotification(Client client) {
+    public static ClientNotification createMockClientNotification(Client client, Caretaker caretaker) {
         return ClientNotification.builder()
                 .objectId(1L)
                 .objectType(ObjectType.CARE)
@@ -35,6 +36,7 @@ public final class MockNotificationProvider {
                 .createdAt(ZonedDateTime.now())
                 .isRead(false)
                 .client(client)
+                .triggeredBy(caretaker)
                 .build();
     }
 

--- a/src/test/java/com/example/petbuddybackend/testutils/mock/MockNotificationProvider.java
+++ b/src/test/java/com/example/petbuddybackend/testutils/mock/MockNotificationProvider.java
@@ -27,6 +27,20 @@ public final class MockNotificationProvider {
                 .build();
     }
 
+    public static CaretakerNotification createMockCaretakerNotification(Caretaker caretaker, Client client, Long id) {
+        return CaretakerNotification.builder()
+                                    .id(id)
+                                    .objectId(1L)
+                                    .objectType(ObjectType.CARE)
+                                    .messageKey("care_reservation")
+                                    .args(Set.of("clientEmail"))
+                                    .createdAt(ZonedDateTime.now())
+                                    .isRead(false)
+                                    .caretaker(caretaker)
+                                    .clientTrigger(client)
+                                    .build();
+    }
+
     public static ClientNotification createMockClientNotification(Client client, Caretaker caretaker) {
         return ClientNotification.builder()
                 .objectId(1L)

--- a/src/test/java/com/example/petbuddybackend/testutils/mock/MockNotificationProvider.java
+++ b/src/test/java/com/example/petbuddybackend/testutils/mock/MockNotificationProvider.java
@@ -23,7 +23,7 @@ public final class MockNotificationProvider {
                 .createdAt(ZonedDateTime.now())
                 .isRead(false)
                 .caretaker(caretaker)
-                .triggeredBy(client)
+                .clientTrigger(client)
                 .build();
     }
 
@@ -36,7 +36,7 @@ public final class MockNotificationProvider {
                 .createdAt(ZonedDateTime.now())
                 .isRead(false)
                 .client(client)
-                .triggeredBy(caretaker)
+                .caretakerTriggered(caretaker)
                 .build();
     }
 

--- a/src/test/java/com/example/petbuddybackend/testutils/mock/MockNotificationProvider.java
+++ b/src/test/java/com/example/petbuddybackend/testutils/mock/MockNotificationProvider.java
@@ -21,7 +21,7 @@ public final class MockNotificationProvider {
                 .messageKey("care_reservation")
                 .args(Set.of("clientEmail"))
                 .createdAt(ZonedDateTime.now())
-                .isRead(false)
+                .read(false)
                 .caretaker(caretaker)
                 .clientTrigger(client)
                 .build();
@@ -35,7 +35,7 @@ public final class MockNotificationProvider {
                                     .messageKey("care_reservation")
                                     .args(Set.of("clientEmail"))
                                     .createdAt(ZonedDateTime.now())
-                                    .isRead(false)
+                                    .read(false)
                                     .caretaker(caretaker)
                                     .clientTrigger(client)
                                     .build();
@@ -48,7 +48,7 @@ public final class MockNotificationProvider {
                 .messageKey("care_update")
                 .args(Set.of("caretakerEmail"))
                 .createdAt(ZonedDateTime.now())
-                .isRead(false)
+                .read(false)
                 .client(client)
                 .caretakerTriggered(caretaker)
                 .build();


### PR DESCRIPTION
Dodanie do powiadomienia dla opikuna informacji o kliencie wraz ze zdjeciem profilowym i na odwrot. Pytanie czy wystarczyloby odswiezac zdjecie profilowe w momencie dodania powiadomienia, nie w momencie wysylania go, zeby nie trzeba bylo czesto tego odswiezac.